### PR TITLE
Change the Code of Conduct to that of the Typelevel community designation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,13 @@
-## Code of Conduct
+# Code of Conduct
 
-Everyone participating in the project is expected to follow [Scala Code of Conduct](https://typelevel.org/code-of-conduct).
+Every member of our community has the right to have their identity respected. The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
+
+Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the project on the available communication channels.
+
+
+## Moderation
+
+If you have any questions, concerns, or moderation requests, please contact a member of the [Typelevel Code of Conduct Committee].
+
+[Typelevel Code of Conduct]: https://typelevel.org/code-of-conduct
+[Typelevel Code of Conduct Committee]: https://typelevel.org/code-of-conduct#contact


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->
Change the Code of Conduct to that of the Typelevel community designation.

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
https://typelevel.org/blog/2024/03/11/code-of-conduct.html
https://github.com/typelevel/governance/pull/134
