### PR TITLE
Feature/2024 03 add com statistics utility commands

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
@@ -25,6 +25,7 @@ import org.typelevel.otel4s.trace.Tracer
 import ldbc.connector.data.CapabilitiesFlags
 import ldbc.connector.net.*
 import ldbc.connector.net.protocol.*
+import ldbc.connector.net.packet.response.StatisticsPacket
 import ldbc.connector.exception.MySQLException
 import ldbc.connector.codec.text.text
 
@@ -198,6 +199,14 @@ trait Connection[F[_]]:
    */
   def getSchema: F[String]
 
+  /**
+   * Retrieves the statistics of this Connection object.
+   *
+   * @return
+   *   the statistics of this Connection object
+   */
+  def getStatistics: F[StatisticsPacket]
+
 object Connection:
 
   private val defaultSocketOptions: List[SocketOption] =
@@ -335,6 +344,8 @@ object Connection:
     override def getSchema: F[String] = protocol.statement("SELECT DATABASE()").executeQuery().map { result =>
       result.decode(text).headOption.getOrElse("")
     }
+
+    override def getStatistics: F[StatisticsPacket] = protocol.getStatistics
 
   def apply[F[_]: Temporal: Network: Console](
     host:                    String,

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
@@ -11,6 +11,7 @@ object CommandId:
   val COM_QUIT         = 0x01
   val COM_INIT_DB      = 0x02
   val COM_QUERY        = 0x03
+  val COM_STATISTICS   = 0x08
   val COM_STMT_PREPARE = 0x16
   val COM_STMT_EXECUTE = 0x17
   val COM_STMT_CLOSE   = 0x19

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
@@ -11,7 +11,7 @@ object CommandId:
   val COM_QUIT         = 0x01
   val COM_INIT_DB      = 0x02
   val COM_QUERY        = 0x03
-  val COM_STATISTICS   = 0x08
+  val COM_STATISTICS   = 0x09
   val COM_STMT_PREPARE = 0x16
   val COM_STMT_EXECUTE = 0x17
   val COM_STMT_CLOSE   = 0x19

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
@@ -112,6 +112,11 @@ trait MySQLProtocol[F[_]]:
    */
   def setSchema(schema: String): F[Unit]
 
+  /**
+   * Returns the statistics of the connection.
+   */
+  def getStatistics: F[StatisticsPacket]
+
 object MySQLProtocol:
 
   case class MySQLProtocolImpl[F[_]: Temporal: Console: Tracer](
@@ -179,6 +184,8 @@ object MySQLProtocol:
     override def close(): F[Unit] = resetSequenceId *> utilityCommands.comQuit()
 
     override def setSchema(schema: String): F[Unit] = resetSequenceId *> utilityCommands.comInitDB(schema)
+
+    override def getStatistics: F[StatisticsPacket] = resetSequenceId *> utilityCommands.comStatistics()
 
   def apply[F[_]: Temporal: Console: Tracer](
     sockets:           Resource[F, Socket[F]],

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComStatisticsPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComStatisticsPacket.scala
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
 package ldbc.connector.net.packet
 package request
 
@@ -23,5 +29,5 @@ case class ComStatisticsPacket() extends RequestPacket:
   override def toString: String = "COM_STATISTICS Request"
 
 object ComStatisticsPacket:
-  
+
   val encoder: Encoder[ComStatisticsPacket] = Encoder(_ => Attempt.successful(BitVector(CommandId.COM_STATISTICS)))

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComStatisticsPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComStatisticsPacket.scala
@@ -1,0 +1,27 @@
+package ldbc.connector.net.packet
+package request
+
+import scodec.*
+import scodec.bits.BitVector
+
+import ldbc.connector.data.CommandId
+
+/**
+ * The COM_STATISTICS request is used to request statistics from the server.
+ * Get a human readable string of some internal status vars.
+ *
+ * The statistics are refreshed at the time of executing this command.
+ * If the returned string is of zero length an error message is returned by mysql_stat to the client application instead of the actual empty statistics string.
+ */
+case class ComStatisticsPacket() extends RequestPacket:
+
+  override protected def encodeBody: Attempt[BitVector] =
+    ComStatisticsPacket.encoder.encode(this)
+
+  override def encode: BitVector = encodeBody.require
+
+  override def toString: String = "COM_STATISTICS Request"
+
+object ComStatisticsPacket:
+  
+  val encoder: Encoder[ComStatisticsPacket] = Encoder(_ => Attempt.successful(BitVector(CommandId.COM_STATISTICS)))

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/StatisticsPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/StatisticsPacket.scala
@@ -33,13 +33,13 @@ import cats.syntax.option.*
  *   The average number of queries executed by the MySQL server per second.
  */
 case class StatisticsPacket(
-  uptime: String,
-  threads: String,
-  questions: String,
-  slowQueries: String,
-  opens: String,
-  flushTables: String,
-  openTables: String,
+  uptime:              String,
+  threads:             String,
+  questions:           String,
+  slowQueries:         String,
+  opens:               String,
+  flushTables:         String,
+  openTables:          String,
   queriesPerSecondAvg: String
 ) extends ResponsePacket:
 
@@ -49,21 +49,21 @@ object StatisticsPacket:
 
   def decoder: Decoder[StatisticsPacket] =
     for
-      _ <- ignore(8 * 8) // "Uptime: " Skip String
-      uptime <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 10) // "  Threads: " Skip String
-      threads <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 12) // "  Questions: " Skip String
-      questions <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 15) // "  Slow queries: " Skip String
-      slowQueries <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 8) // "  Opens: " Skip String
-      opens <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 15) // "  Flush tables: " Skip String
-      flushTables <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 14) // "  Open tables: " Skip String
-      openTables <- spaceDelimitedStringDecoder
-      _ <- ignore(8 * 25) // " Queries per second avg: " Skip String
+      _                   <- ignore(8 * 8)  // "Uptime: " Skip String
+      uptime              <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 10) // "  Threads: " Skip String
+      threads             <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 12) // "  Questions: " Skip String
+      questions           <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 15) // "  Slow queries: " Skip String
+      slowQueries         <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 8)  // "  Opens: " Skip String
+      opens               <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 15) // "  Flush tables: " Skip String
+      flushTables         <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 14) // "  Open tables: " Skip String
+      openTables          <- spaceDelimitedStringDecoder
+      _                   <- ignore(8 * 25) // " Queries per second avg: " Skip String
       queriesPerSecondAvg <- spaceDelimitedStringDecoder
     yield StatisticsPacket(
       uptime,

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/StatisticsPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/StatisticsPacket.scala
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.net.packet
+package response
+
+import scodec.*
+import scodec.codecs.*
+
+import cats.syntax.option.*
+
+/**
+ * StatisticsPacket is a response packet that contains the statistics of the MySQL server.
+ *
+ * @param uptime
+ *   The uptime of the MySQL server.
+ * @param threads
+ *   The number of threads connected to the MySQL server.
+ * @param questions
+ *   The number of questions sent to the MySQL server.
+ * @param slowQueries
+ *   Total number of queries received since the MySQL server started.
+ * @param opens
+ *   The number of tables opened by the MySQL server.
+ * @param flushTables
+ *   The number of tables flushed by the MySQL server.
+ * @param openTables
+ *   Number of open tables currently held in the cache.
+ * @param queriesPerSecondAvg
+ *   The average number of queries executed by the MySQL server per second.
+ */
+case class StatisticsPacket(
+  uptime: String,
+  threads: String,
+  questions: String,
+  slowQueries: String,
+  opens: String,
+  flushTables: String,
+  openTables: String,
+  queriesPerSecondAvg: String
+) extends ResponsePacket:
+
+  override def toString: String = "COM_STATISTICS Response Packet"
+
+object StatisticsPacket:
+
+  def decoder: Decoder[StatisticsPacket] =
+    for
+      _ <- ignore(8 * 8) // "Uptime: " Skip String
+      uptime <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 10) // "  Threads: " Skip String
+      threads <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 12) // "  Questions: " Skip String
+      questions <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 15) // "  Slow queries: " Skip String
+      slowQueries <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 8) // "  Opens: " Skip String
+      opens <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 15) // "  Flush tables: " Skip String
+      flushTables <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 14) // "  Open tables: " Skip String
+      openTables <- spaceDelimitedStringDecoder
+      _ <- ignore(8 * 25) // " Queries per second avg: " Skip String
+      queriesPerSecondAvg <- spaceDelimitedStringDecoder
+    yield StatisticsPacket(
+      uptime,
+      threads.replace("Threads: ", ""),
+      questions,
+      slowQueries,
+      opens,
+      flushTables,
+      openTables,
+      queriesPerSecondAvg
+    )

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -285,12 +285,12 @@ class ConnectionTest extends CatsEffectSuite:
 
   test("Statistics of the MySQL server can be obtained.") {
     val connection = Connection[IO](
-      host = "127.0.0.1",
-      port = 13306,
-      user = "ldbc",
+      host     = "127.0.0.1",
+      port     = 13306,
+      user     = "ldbc",
       password = Some("password"),
       database = Some("connector_test"),
-      ssl = SSL.Trusted
+      ssl      = SSL.Trusted
     )
 
     assertIO(

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -282,3 +282,19 @@ class ConnectionTest extends CatsEffectSuite:
       "world"
     )
   }
+
+  test("Statistics of the MySQL server can be obtained.") {
+    val connection = Connection[IO](
+      host = "127.0.0.1",
+      port = 13306,
+      user = "ldbc",
+      password = Some("password"),
+      database = Some("connector_test"),
+      ssl = SSL.Trusted
+    )
+
+    assertIO(
+      connection.use(_.getStatistics.map(_.toString)),
+      "COM_STATISTICS Response Packet"
+    )
+  }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Add a command to retrieve MySQL server statistics.

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
