### PR TITLE
Feature/2024 04 add com reset connection utility commands

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
@@ -211,7 +211,7 @@ trait Connection[F[_]]:
    * Returns true if the connection has not been closed and is still valid.
    */
   def isValid: F[Boolean]
-  
+
   /**
    * Resets the server-side state of this connection. 
    */
@@ -358,7 +358,7 @@ object Connection:
     override def getStatistics: F[StatisticsPacket] = protocol.getStatistics
 
     override def isValid: F[Boolean] = protocol.isValid
-    
+
     override def resetServerState: F[Unit] =
       protocol.resetConnection *>
         protocol.statement("SET NAMES utf8mb4").executeQuery() *>

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CommandId.scala
@@ -8,11 +8,12 @@ package ldbc.connector.data
 
 object CommandId:
 
-  val COM_QUIT         = 0x01
-  val COM_INIT_DB      = 0x02
-  val COM_QUERY        = 0x03
-  val COM_STATISTICS   = 0x09
-  val COM_PING         = 0x0e
-  val COM_STMT_PREPARE = 0x16
-  val COM_STMT_EXECUTE = 0x17
-  val COM_STMT_CLOSE   = 0x19
+  val COM_QUIT             = 0x01
+  val COM_INIT_DB          = 0x02
+  val COM_QUERY            = 0x03
+  val COM_STATISTICS       = 0x09
+  val COM_PING             = 0x0e
+  val COM_STMT_PREPARE     = 0x16
+  val COM_STMT_EXECUTE     = 0x17
+  val COM_STMT_CLOSE       = 0x19
+  val COM_RESET_CONNECTION = 0x1f

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
@@ -121,7 +121,7 @@ trait MySQLProtocol[F[_]]:
    * Returns true if the connection has not been closed and is still valid.
    */
   def isValid: F[Boolean]
-  
+
   /**
    * Resets the connection.
    */
@@ -198,7 +198,7 @@ object MySQLProtocol:
     override def getStatistics: F[StatisticsPacket] = resetSequenceId *> utilityCommands.comStatistics()
 
     override def isValid: F[Boolean] = resetSequenceId *> utilityCommands.comPing()
-    
+
     override def resetConnection: F[Unit] = resetSequenceId *> utilityCommands.comResetConnection()
 
   def apply[F[_]: Temporal: Console: Tracer](

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/MySQLProtocol.scala
@@ -121,6 +121,11 @@ trait MySQLProtocol[F[_]]:
    * Returns true if the connection has not been closed and is still valid.
    */
   def isValid: F[Boolean]
+  
+  /**
+   * Resets the connection.
+   */
+  def resetConnection: F[Unit]
 
 object MySQLProtocol:
 
@@ -193,6 +198,8 @@ object MySQLProtocol:
     override def getStatistics: F[StatisticsPacket] = resetSequenceId *> utilityCommands.comStatistics()
 
     override def isValid: F[Boolean] = resetSequenceId *> utilityCommands.comPing()
+    
+    override def resetConnection: F[Unit] = resetSequenceId *> utilityCommands.comResetConnection()
 
   def apply[F[_]: Temporal: Console: Tracer](
     sockets:           Resource[F, Socket[F]],

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
@@ -23,4 +23,5 @@ case class ComResetConnectionPacket() extends RequestPacket:
 
 object ComResetConnectionPacket:
 
-  val encoder: Encoder[ComResetConnectionPacket] = Encoder(_ => Attempt.successful(BitVector(CommandId.COM_RESET_CONNECTION)))
+  val encoder: Encoder[ComResetConnectionPacket] =
+    Encoder(_ => Attempt.successful(BitVector(CommandId.COM_RESET_CONNECTION)))

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.net.packet
+package request
+
+import scodec.*
+import scodec.bits.BitVector
+
+import ldbc.connector.data.CommandId
+
+case class ComResetConnectionPacket() extends RequestPacket:
+
+  override protected def encodeBody: Attempt[BitVector] =
+    ComResetConnectionPacket.encoder.encode(this)
+
+  override def encode: BitVector = encodeBody.require
+
+  override def toString: String = "COM_RESET_CONNECTION Request"
+
+object ComResetConnectionPacket:
+
+  val encoder: Encoder[ComResetConnectionPacket] = Encoder(_ => Attempt.successful(BitVector(CommandId.COM_RESET_CONNECTION)))

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/request/ComResetConnectionPacket.scala
@@ -12,6 +12,9 @@ import scodec.bits.BitVector
 
 import ldbc.connector.data.CommandId
 
+/**
+ * A request packet to reset the connection.
+ */
 case class ComResetConnectionPacket() extends RequestPacket:
 
   override protected def encodeBody: Attempt[BitVector] =

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/UtilityCommands.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/UtilityCommands.scala
@@ -46,6 +46,11 @@ trait UtilityCommands[F[_]]:
    * Check if the server is alive.
    */
   def comPing(): F[Boolean]
+  
+  /**
+   * Reset the connection
+   */
+  def comResetConnection(): F[Unit]
 
 object UtilityCommands:
 
@@ -88,5 +93,15 @@ object UtilityCommands:
             socket.receive(GenericResponsePackets.decoder(initialPacket.capabilityFlags)).flatMap {
               case error: ERRPacket => ev.pure(false)
               case ok: OKPacket     => ev.pure(true)
+            }
+        }
+        
+      override def comResetConnection(): F[Unit] =
+        exchange[F, Unit]("utility_commands") { (span: Span[F]) =>
+          span.addAttributes((attributes :+ Attribute("command", "COM_RESET_CONNECTION"))*) *>
+            socket.send(ComResetConnectionPacket()) *>
+            socket.receive(GenericResponsePackets.decoder(initialPacket.capabilityFlags)).flatMap {
+              case error: ERRPacket => ev.raiseError(error.toException("Failed to execute reset connection"))
+              case ok: OKPacket => ev.unit
             }
         }

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/UtilityCommands.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/UtilityCommands.scala
@@ -46,7 +46,7 @@ trait UtilityCommands[F[_]]:
    * Check if the server is alive.
    */
   def comPing(): F[Boolean]
-  
+
   /**
    * Reset the connection
    */
@@ -95,13 +95,13 @@ object UtilityCommands:
               case ok: OKPacket     => ev.pure(true)
             }
         }
-        
+
       override def comResetConnection(): F[Unit] =
         exchange[F, Unit]("utility_commands") { (span: Span[F]) =>
           span.addAttributes((attributes :+ Attribute("command", "COM_RESET_CONNECTION"))*) *>
             socket.send(ComResetConnectionPacket()) *>
             socket.receive(GenericResponsePackets.decoder(initialPacket.capabilityFlags)).flatMap {
               case error: ERRPacket => ev.raiseError(error.toException("Failed to execute reset connection"))
-              case ok: OKPacket => ev.unit
+              case ok: OKPacket     => ev.unit
             }
         }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -314,12 +314,12 @@ class ConnectionTest extends CatsEffectSuite:
 
   test("Connection state reset succeeds.") {
     val connection = Connection[IO](
-      host                    = "127.0.0.1",
-      port                    = 13306,
-      user                    = "ldbc",
-      password                = Some("password"),
-      database                = Some("connector_test"),
-      allowPublicKeyRetrieval = true
+      host     = "127.0.0.1",
+      port     = 13306,
+      user     = "ldbc",
+      password = Some("password"),
+      database = Some("connector_test"),
+      ssl      = SSL.Trusted
     )
 
     assertIOBoolean(connection.use(_.resetServerState) *> IO(true))

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -306,8 +306,21 @@ class ConnectionTest extends CatsEffectSuite:
       user                    = "ldbc",
       password                = Some("password"),
       database                = Some("connector_test"),
-      allowPublicKeyRetrieval = true
+      ssl                     = SSL.Trusted,
     )
 
     assertIOBoolean(connection.use(_.isValid))
+  }
+
+  test("Connection state reset succeeds.") {
+    val connection = Connection[IO](
+      host                    = "127.0.0.1",
+      port                    = 13306,
+      user                    = "ldbc",
+      password                = Some("password"),
+      database                = Some("connector_test"),
+      allowPublicKeyRetrieval = true
+    )
+
+    assertIOBoolean(connection.use(_.resetServerState) *> IO(true))
   }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -301,12 +301,12 @@ class ConnectionTest extends CatsEffectSuite:
 
   test("The connection is valid.") {
     val connection = Connection[IO](
-      host                    = "127.0.0.1",
-      port                    = 13306,
-      user                    = "ldbc",
-      password                = Some("password"),
-      database                = Some("connector_test"),
-      ssl                     = SSL.Trusted,
+      host     = "127.0.0.1",
+      port     = 13306,
+      user     = "ldbc",
+      password = Some("password"),
+      database = Some("connector_test"),
+      ssl      = SSL.Trusted
     )
 
     assertIOBoolean(connection.use(_.isValid))


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Add a command to reset the MySQL server connection state.

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
