### PR TITLE
Hotfix/2024 09 fixed result set get by name

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -454,7 +454,8 @@ private[ldbc] case class ResultSetImpl(
   private def findByName(columnLabel: String): Option[(ColumnDefinitionPacket, Int)] =
     columns.zipWithIndex.find {
       case (column: ColumnDefinition41Packet, _) =>
-        if column.table != column.orgTable then (column.table + "." + column.name).toLowerCase == columnLabel.toLowerCase
+        if column.table != column.orgTable then
+          (column.table + "." + column.name).toLowerCase == columnLabel.toLowerCase
         else column.name == columnLabel
       case (column: ColumnDefinition320Packet, _) => column.name == columnLabel
     }

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -453,7 +453,7 @@ private[ldbc] case class ResultSetImpl(
 
   private def findByName(columnLabel: String): Option[(ColumnDefinitionPacket, Int)] =
     columns.zipWithIndex.find { (column: ColumnDefinitionPacket, _) =>
-        column.name == columnLabel || column.fullName == columnLabel
+      column.name == columnLabel || column.fullName == columnLabel
     }
 
   private def raiseError[T](message: String): T =

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -453,7 +453,7 @@ private[ldbc] case class ResultSetImpl(
 
   private def findByName(columnLabel: String): Option[(ColumnDefinitionPacket, Int)] =
     columns.zipWithIndex.find { (column: ColumnDefinitionPacket, _) =>
-      column.name == columnLabel || column.fullName == columnLabel
+      column.name.equalsIgnoreCase(columnLabel) || column.fullName.equalsIgnoreCase(columnLabel)
     }
 
   private def raiseError[T](message: String): T =

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -182,7 +182,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getString(columnLabel: String): String =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getString(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -191,7 +191,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getBoolean(columnLabel: String): Boolean =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getBoolean(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -200,7 +200,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getByte(columnLabel: String): Byte =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getByte(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -209,7 +209,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getShort(columnLabel: String): Short =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getShort(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -218,7 +218,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getInt(columnLabel: String): Int =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getInt(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -227,7 +227,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getLong(columnLabel: String): Long =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getLong(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -236,7 +236,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getFloat(columnLabel: String): Float =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getFloat(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -245,7 +245,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getDouble(columnLabel: String): Double =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getDouble(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -254,7 +254,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getBytes(columnLabel: String): Array[Byte] =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getBytes(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -263,7 +263,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getDate(columnLabel: String): LocalDate =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getDate(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -272,7 +272,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getTime(columnLabel: String): LocalTime =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getTime(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -281,7 +281,7 @@ private[ldbc] case class ResultSetImpl(
 
   override def getTimestamp(columnLabel: String): LocalDateTime =
     checkClose {
-      columns.zipWithIndex.find(_._1.name == columnLabel) match
+      findByName(columnLabel) match
         case Some((_, index)) => getTimestamp(index + 1)
         case None =>
           lastColumnReadNullable = true
@@ -450,6 +450,14 @@ private[ldbc] case class ResultSetImpl(
 
   private def rowDecode[T](decode: ResultSetRowPacket => Option[T]): Option[T] =
     currentRow.flatMap(decode)
+
+  private def findByName(columnLabel: String): Option[(ColumnDefinitionPacket, Int)] =
+    columns.zipWithIndex.find {
+      case (column: ColumnDefinition41Packet, _) =>
+        if column.table != column.orgTable then (column.table + "." + column.name).toLowerCase == columnLabel.toLowerCase
+        else column.name == columnLabel
+      case (column: ColumnDefinition320Packet, _) => column.name == columnLabel
+    }
 
   private def raiseError[T](message: String): T =
     throw new SQLException(message)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -452,12 +452,8 @@ private[ldbc] case class ResultSetImpl(
     currentRow.flatMap(decode)
 
   private def findByName(columnLabel: String): Option[(ColumnDefinitionPacket, Int)] =
-    columns.zipWithIndex.find {
-      case (column: ColumnDefinition41Packet, _) =>
-        if column.table != column.orgTable then
-          (column.table + "." + column.name).toLowerCase == columnLabel.toLowerCase
-        else column.name == columnLabel
-      case (column: ColumnDefinition320Packet, _) => column.name == columnLabel
+    columns.zipWithIndex.find { (column: ColumnDefinitionPacket, _) =>
+        column.name == columnLabel || column.fullName == columnLabel
     }
 
   private def raiseError[T](message: String): T =

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ColumnDefinitionPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ColumnDefinitionPacket.scala
@@ -28,7 +28,7 @@ trait ColumnDefinitionPacket extends ResponsePacket:
 
   /** ColumnDefinitionFlags is a bitset of column definition flags. */
   def flags: Seq[ColumnDefinitionFlags]
-  
+
   /** Full name with table and column names connected by dots */
   def fullName: String = table + "." + name
 

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ColumnDefinitionPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ColumnDefinitionPacket.scala
@@ -28,6 +28,9 @@ trait ColumnDefinitionPacket extends ResponsePacket:
 
   /** ColumnDefinitionFlags is a bitset of column definition flags. */
   def flags: Seq[ColumnDefinitionFlags]
+  
+  /** Full name with table and column names connected by dots */
+  def fullName: String = table + "." + name
 
 object ColumnDefinitionPacket:
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ResultSetTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ResultSetTest.scala
@@ -320,7 +320,9 @@ class ResultSetTest extends FTestPlatform:
     assertEquals(builder.result(), List((1, 2, 0), (3, 4, 0), (5, 6, 0), (7, 8, 0)))
   }
 
-  test("If the table name is replaced by an alias, the record can be retrieved by specifying the table name and column name together.") {
+  test(
+    "If the table name is replaced by an alias, the record can be retrieved by specifying the table name and column name together."
+  ) {
     val resultSet = buildResultSet(
       Vector(
         column("c1", ColumnDataType.MYSQL_TYPE_TINY, Some("t")),
@@ -405,7 +407,7 @@ class ResultSetTest extends FTestPlatform:
   test("The column label obtained from the meta-information of ResultSet matches the specified value.") {
     val resultSet = buildResultSet(
       Vector(
-        column("c1", ColumnDataType.MYSQL_TYPE_LONG, alias = Some("label1")),
+        column("c1", ColumnDataType.MYSQL_TYPE_LONG, alias   = Some("label1")),
         column("c2", ColumnDataType.MYSQL_TYPE_DOUBLE, alias = Some("label2")),
         column("c3", ColumnDataType.MYSQL_TYPE_STRING, alias = Some("label3"))
       ),
@@ -1031,7 +1033,7 @@ class ResultSetTest extends FTestPlatform:
   private def column(
     columnName: String,
     `type`:     ColumnDataType,
-    table:     Option[String] = None,
+    table:      Option[String] = None,
     alias:      Option[String] = None,
     useScale:   Boolean = false,
     isSigned:   Boolean = false,


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

The process to retrieve records by matching the table name and column name, such as when using JOIN, does not work as intended.

```scala
sql"SELECT c.Id, c.Name, ct.Code, ct.Name FROM city AS c JOIN country AS ct ON c.CountryCode = ct.Code"
  .query[(Int, String, String, String)]
```

There is no problem in retrieving records by specifying the Index, but when retrieving records by specifying the column name internally, the records are not retrieved correctly because they are retrieved as `Id` instead of `c.Id`.

JDBC allows the retrieval of records by the combination of table name and column name, so the modification was made accordingly.

https://github.com/mysql/mysql-connector-j/blob/release/8.x/src/main/core-impl/java/com/mysql/cj/result/DefaultColumnDefinition.java#L204-L210

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
