### PR TITLE
Enhancement/2024 09 raises errors in fields that cannot be decoded

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/ResultSetImpl.scala
@@ -24,9 +24,9 @@ private[ldbc] case class ResultSetImpl(
   records:              Vector[ResultSetRowPacket],
   serverVariables:      Map[String, String],
   version:              Version,
-  resultSetType:        Int = ResultSet.TYPE_FORWARD_ONLY,
-  resultSetConcurrency: Int = ResultSet.CONCUR_READ_ONLY,
-  statement: Option[String] = None
+  resultSetType:        Int            = ResultSet.TYPE_FORWARD_ONLY,
+  resultSetConcurrency: Int            = ResultSet.CONCUR_READ_ONLY,
+  statement:            Option[String] = None
 ) extends ResultSet:
 
   private final var isClosed:               Boolean                    = false
@@ -414,9 +414,16 @@ private[ldbc] case class ResultSetImpl(
     currentRow.flatMap(decode)
 
   private def findByName(columnLabel: String): Int =
-    columns.zipWithIndex.find { (column: ColumnDefinitionPacket, _) =>
-      column.name.equalsIgnoreCase(columnLabel) || column.fullName.equalsIgnoreCase(columnLabel)
-    }.map(_._2).getOrElse(raiseError(s"${Console.CYAN}Column name '${Console.RED}$columnLabel${Console.CYAN}' does not exist in the ResultSet."))
+    columns.zipWithIndex
+      .find { (column: ColumnDefinitionPacket, _) =>
+        column.name.equalsIgnoreCase(columnLabel) || column.fullName.equalsIgnoreCase(columnLabel)
+      }
+      .map(_._2)
+      .getOrElse(
+        raiseError(
+          s"${ Console.CYAN }Column name '${ Console.RED }$columnLabel${ Console.CYAN }' does not exist in the ResultSet."
+        )
+      )
 
   private def raiseError[T](message: String): T =
     throw new SQLException(message, sql = statement)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
@@ -102,7 +102,8 @@ case class ClientPreparedStatement[F[_]: Temporal: Exchange: Tracer](
                               serverVariables,
                               protocol.initialPacket.serverVersion,
                               resultSetType,
-                              resultSetConcurrency
+                              resultSetConcurrency,
+                  Some(sql)
                             )
                 _ <- currentResultSet.set(Some(resultSet))
               yield resultSet

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
@@ -103,7 +103,7 @@ case class ClientPreparedStatement[F[_]: Temporal: Exchange: Tracer](
                               protocol.initialPacket.serverVersion,
                               resultSetType,
                               resultSetConcurrency,
-                  Some(sql)
+                              Some(sql)
                             )
                 _ <- currentResultSet.set(Some(resultSet))
               yield resultSet

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
@@ -99,7 +99,7 @@ case class ServerPreparedStatement[F[_]: Temporal: Exchange: Tracer](
                       protocol.initialPacket.serverVersion,
                       resultSetType,
                       resultSetConcurrency,
-          Some(sql)
+                      Some(sql)
                     )
         _ <- currentResultSet.set(Some(resultSet))
       yield resultSet

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
@@ -98,7 +98,8 @@ case class ServerPreparedStatement[F[_]: Temporal: Exchange: Tracer](
                       serverVariables,
                       protocol.initialPacket.serverVersion,
                       resultSetType,
-                      resultSetConcurrency
+                      resultSetConcurrency,
+          Some(sql)
                     )
         _ <- currentResultSet.set(Some(resultSet))
       yield resultSet

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -79,7 +79,7 @@ private[ldbc] case class StatementImpl[F[_]: Temporal: Exchange: Tracer](
                             protocol.initialPacket.serverVersion,
                             resultSetType,
                             resultSetConcurrency,
-                Some(sql)
+                            Some(sql)
                           )
               _ <- currentResultSet.set(Some(resultSet))
             yield resultSet

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -78,7 +78,8 @@ private[ldbc] case class StatementImpl[F[_]: Temporal: Exchange: Tracer](
                             serverVariables,
                             protocol.initialPacket.serverVersion,
                             resultSetType,
-                            resultSetConcurrency
+                            resultSetConcurrency,
+                Some(sql)
                           )
               _ <- currentResultSet.set(Some(resultSet))
             yield resultSet

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -47,7 +47,10 @@ object Decoder:
    * @tparam A
    *   Scala types that match SQL DataType
    */
-  trait Elem[A]:
+  class Elem[A](
+    decodeLabel: ResultSet => String => A,
+    decodeIndex: ResultSet => Int => A
+  ):
 
     /**
      * Method to retrieve data from a ResultSet using column names.
@@ -58,7 +61,7 @@ object Decoder:
      * @param columnLabel
      * Column name of the data to be retrieved from the ResultSet.
      */
-    def decode(resultSet: ResultSet, columnLabel: String): A
+    def decode(resultSet: ResultSet, columnLabel: String): A = decodeLabel(resultSet)(columnLabel)
 
     /**
      * Method to retrieve data from a ResultSet using an Index number.
@@ -69,23 +72,13 @@ object Decoder:
      * @param index
      * Index number of the data to be retrieved from the ResultSet.
      */
-    def decode(resultSet: ResultSet, index: Int): A
+    def decode(resultSet: ResultSet, index: Int): A = decodeIndex(resultSet)(index)
 
   object Elem:
-    def apply[T](
-      decodeLabel: ResultSet => String => T,
-      decodeIndex: ResultSet => Int => T
-    ): Elem[T] =
-      new Elem[T]:
-        override def decode(resultSet: ResultSet, columnLabel: String): T =
-          decodeLabel(resultSet)(columnLabel)
-
-        override def decode(resultSet: ResultSet, index: Int): T =
-          decodeIndex(resultSet)(index)
 
     given Functor[[T] =>> Elem[T]] with
       override def map[A, B](fa: Elem[A])(f: A => B): Elem[B] =
-        Elem(
+        new Elem(
           resultSet => columnLabel => f(fa.decode(resultSet, columnLabel)),
           resultSet => index => f(fa.decode(resultSet, index))
         )
@@ -105,19 +98,19 @@ object Decoder:
     def mapping[A, B](f: A => B)(using decoder: Decoder.Elem[A]): Decoder.Elem[B] =
       decoder.map(f(_))
 
-    given Elem[String]        = Elem(_.getString, _.getString)
-    given Elem[Boolean]       = Elem(_.getBoolean, _.getBoolean)
-    given Elem[Byte]          = Elem(_.getByte, _.getByte)
-    given Elem[Array[Byte]]   = Elem(_.getBytes, _.getBytes)
-    given Elem[Short]         = Elem(_.getShort, _.getShort)
-    given Elem[Int]           = Elem(_.getInt, _.getInt)
-    given Elem[Long]          = Elem(_.getLong, _.getLong)
-    given Elem[Float]         = Elem(_.getFloat, _.getFloat)
-    given Elem[Double]        = Elem(_.getDouble, _.getDouble)
-    given Elem[LocalDate]     = Elem(_.getDate, _.getDate)
-    given Elem[LocalTime]     = Elem(_.getTime, _.getTime)
-    given Elem[LocalDateTime] = Elem(_.getTimestamp, _.getTimestamp)
-    given Elem[BigDecimal]    = Elem(_.getBigDecimal, _.getBigDecimal)
+    given Elem[String]        = new Elem(_.getString, _.getString)
+    given Elem[Boolean]       = new Elem(_.getBoolean, _.getBoolean)
+    given Elem[Byte]          = new Elem(_.getByte, _.getByte)
+    given Elem[Array[Byte]]   = new Elem(_.getBytes, _.getBytes)
+    given Elem[Short]         = new Elem(_.getShort, _.getShort)
+    given Elem[Int]           = new Elem(_.getInt, _.getInt)
+    given Elem[Long]          = new Elem(_.getLong, _.getLong)
+    given Elem[Float]         = new Elem(_.getFloat, _.getFloat)
+    given Elem[Double]        = new Elem(_.getDouble, _.getDouble)
+    given Elem[LocalDate]     = new Elem(_.getDate, _.getDate)
+    given Elem[LocalTime]     = new Elem(_.getTime, _.getTime)
+    given Elem[LocalDateTime] = new Elem(_.getTimestamp, _.getTimestamp)
+    given Elem[BigDecimal]    = new Elem(_.getBigDecimal, _.getBigDecimal)
 
     given (using decoder: Elem[String]): Elem[BigInt] =
       decoder.map(str => if str == null then null else BigInt(str))
@@ -128,14 +121,15 @@ object Decoder:
     given (using decoder: Elem[String]): Elem[YearMonth] =
       decoder.map(str => YearMonth.parse(str))
 
-    given [A](using decoder: Elem[A]): Elem[Option[A]] with
-      override def decode(resultSet: ResultSet, columnLabel: String): Option[A] =
-        val value = decoder.decode(resultSet, columnLabel)
-        if resultSet.wasNull() then None else Some(value)
-
-      override def decode(resultSet: ResultSet, index: Int): Option[A] =
-        val value = decoder.decode(resultSet, index)
-        if resultSet.wasNull() then None else Some(value)
+    given [A](using decoder: Elem[A]): Elem[Option[A]] =
+      new Elem(
+        resultSet => columnLabel =>
+          val value = decoder.decode(resultSet, columnLabel)
+          if resultSet.wasNull() then None else Some(value),
+        resultSet => index =>
+          val value = decoder.decode(resultSet, index)
+          if resultSet.wasNull() then None else Some(value)
+      )
 
   def one[A](using decoder: Decoder.Elem[A]): Decoder[A] =
     new Decoder((resultSet, prefix) => decoder.decode(resultSet, 1))

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -123,12 +123,15 @@ object Decoder:
 
     given [A](using decoder: Elem[A]): Elem[Option[A]] =
       new Elem(
-        resultSet => columnLabel =>
-          val value = decoder.decode(resultSet, columnLabel)
-          if resultSet.wasNull() then None else Some(value),
-        resultSet => index =>
-          val value = decoder.decode(resultSet, index)
-          if resultSet.wasNull() then None else Some(value)
+        resultSet =>
+          columnLabel =>
+            val value = decoder.decode(resultSet, columnLabel)
+            if resultSet.wasNull() then None else Some(value)
+        ,
+        resultSet =>
+          index =>
+            val value = decoder.decode(resultSet, index)
+            if resultSet.wasNull() then None else Some(value)
       )
 
   def one[A](using decoder: Decoder.Elem[A]): Decoder[A] =

--- a/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -33,7 +33,9 @@ class LdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
       ssl      = SSL.Trusted
     )
 
-  test("If the acquired column name and the field name of the class to be mapped are different, an exception is raised.") {
+  test(
+    "If the acquired column name and the field name of the class to be mapped are different, an exception is raised."
+  ) {
     case class City(id: Int, title: String)
 
     interceptIO[ldbc.connector.exception.SQLException](
@@ -46,7 +48,9 @@ class LdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
     )
   }
 
-  test("If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised.") {
+  test(
+    "If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised."
+  ) {
     case class City(id: Int, name: String, age: Int)
 
     interceptIO[ldbc.connector.exception.SQLException](
@@ -71,7 +75,9 @@ class JdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
   override def connection: Resource[IO, Connection[IO]] =
     Resource.make(jdbc.connector.MysqlDataSource[IO](ds).getConnection)(_.close())
 
-  test("If the acquired column name and the field name of the class to be mapped are different, an exception is raised.") {
+  test(
+    "If the acquired column name and the field name of the class to be mapped are different, an exception is raised."
+  ) {
     case class City(id: Int, title: String)
 
     interceptIO[java.sql.SQLException](
@@ -84,7 +90,9 @@ class JdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
     )
   }
 
-  test("If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised.") {
+  test(
+    "If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised."
+  ) {
     case class City(id: Int, name: String, age: Int)
 
     interceptIO[java.sql.SQLException](

--- a/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -33,6 +33,32 @@ class LdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
       ssl      = SSL.Trusted
     )
 
+  test("If the acquired column name and the field name of the class to be mapped are different, an exception is raised.") {
+    case class City(id: Int, title: String)
+
+    interceptIO[ldbc.connector.exception.SQLException](
+      connection.use { conn =>
+        sql"SELECT Id, Name FROM city LIMIT 1"
+          .query[City]
+          .to[Option]
+          .readOnly(conn)
+      }
+    )
+  }
+
+  test("If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised.") {
+    case class City(id: Int, name: String, age: Int)
+
+    interceptIO[ldbc.connector.exception.SQLException](
+      connection.use { conn =>
+        sql"SELECT Id, Name FROM city LIMIT 1"
+          .query[City]
+          .to[Option]
+          .readOnly(conn)
+      }
+    )
+  }
+
 class JdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
 
   val ds = new MysqlDataSource()
@@ -44,6 +70,32 @@ class JdbcSQLStringContextQueryTest extends SQLStringContextQueryTest:
 
   override def connection: Resource[IO, Connection[IO]] =
     Resource.make(jdbc.connector.MysqlDataSource[IO](ds).getConnection)(_.close())
+
+  test("If the acquired column name and the field name of the class to be mapped are different, an exception is raised.") {
+    case class City(id: Int, title: String)
+
+    interceptIO[java.sql.SQLException](
+      connection.use { conn =>
+        sql"SELECT Id, Name FROM city LIMIT 1"
+          .query[City]
+          .to[Option]
+          .readOnly(conn)
+      }
+    )
+  }
+
+  test("If the number of columns retrieved is different from the number of fields in the class to be mapped, an exception is raised.") {
+    case class City(id: Int, name: String, age: Int)
+
+    interceptIO[java.sql.SQLException](
+      connection.use { conn =>
+        sql"SELECT Id, Name FROM city LIMIT 1"
+          .query[City]
+          .to[Option]
+          .readOnly(conn)
+      }
+    )
+  }
 
 trait SQLStringContextQueryTest extends CatsEffectSuite:
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

If there is no column that matches (cannot be mapped to) a field of the class passed in `query[Hoge]`, it is not set to null, but an error is returned.

This is a known bug and was a normal error in jdbc.

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
