### PR TITLE
Enhancement/2024 10 added support tuple class mapping

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -156,7 +156,8 @@ object Decoder:
         // When selecting columns with a Select statement, no more than two `. ` is never used more than once when selecting a column in a Select statement.
         // Therefore, if the length of the columns is greater than 2, it is assumed that the column name is specified in the format `table`.`column`.
         // To support mapping to both nested classes and class Tuple`. ` to support mapping to both nested classes and class tuples.
-        val column = if columns.length > 2 then columns.tail.mkString(".") else constValue[mirror.MirroredLabel] ++ "." ++ label
+        val column =
+          if columns.length > 2 then columns.tail.mkString(".") else constValue[mirror.MirroredLabel] ++ "." ++ label
         decoder match
           case dm: Decoder.Elem[t] => dm.decode(resultSet, column)
           case d: Decoder[t]       => d.decode(resultSet, Some(column))

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -152,7 +152,11 @@ object Decoder:
 
     new Decoder[A]((resultSet: ResultSet, prefix: Option[String]) =>
       val results = labels.zip(decodes).map { (label, decoder) =>
-        val column = prefix.map(_ + ".").getOrElse("") + label
+        val columns = (prefix.map(_ + ".").getOrElse("") + label).split('.')
+        // When selecting columns with a Select statement, no more than two `. ` is never used more than once when selecting a column in a Select statement.
+        // Therefore, if the length of the columns is greater than 2, it is assumed that the column name is specified in the format `table`.`column`.
+        // To support mapping to both nested classes and class Tuple`. ` to support mapping to both nested classes and class tuples.
+        val column = if columns.length > 2 then columns.tail.mkString(".") else constValue[mirror.MirroredLabel] ++ "." ++ label
         decoder match
           case dm: Decoder.Elem[t] => dm.decode(resultSet, column)
           case d: Decoder[t]       => d.decode(resultSet, Some(column))

--- a/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -773,3 +773,18 @@ trait SQLStringContextQueryTest extends CatsEffectSuite:
       Some(CityWithCountry(City(1, "Kabul"), Country("AFG", "Afghanistan")))
     )
   }
+
+  test("The results obtained by JOIN can be mapped to the class Tuple.") {
+    case class City(id: Int, name: String)
+    case class Country(code: String, name: String)
+
+    assertIO(
+      connection.use { conn =>
+        sql"SELECT city.Id, city.Name, country.Code, country.Name FROM city JOIN country ON city.CountryCode = country.Code LIMIT 1"
+          .query[(City, Country)]
+          .to[Option]
+          .readOnly(conn)
+      },
+      Some((City(1, "Kabul"), Country("AFG", "Afghanistan")))
+    )
+  }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Mapping to currently nested classes can be done using class field names, etc.
However, it is not possible to perform a conversion to a Tuple class.
So, the class name from Mirror's information is used to enable conversion to a Tuple state class.

**Example**

```scala 3
case class City(id: Int, name: String)
case class Country(code: String, name: String)

sql"SELECT city.Id, city.Name, country.Code, country.Name FROM city JOIN country ON city.CountryCode = country.Code LIMIT 1"
  .query[(City, Country)]
  .to[Option]
  .readOnly(conn)
```

However, there is a restriction on this: the table name and class name must be equivalent.
This means that if you shorten the table name from `city` to `c`, etc., using aliases, etc., the class name must also be `C`.

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
