### PR TITLE
Delete cardinality property

### DIFF
--- a/tests/src/test/scala/ldbc/tests/DatabaseMetaDataTest.scala
+++ b/tests/src/test/scala/ldbc/tests/DatabaseMetaDataTest.scala
@@ -1770,14 +1770,13 @@ trait DatabaseMetaDataTest extends CatsEffectSuite:
             val ordinalPosition = resultSet.getInt("ORDINAL_POSITION")
             val columnName      = resultSet.getString("COLUMN_NAME")
             val ascOrDesc       = resultSet.getString("ASC_OR_DESC")
-            val cardinality     = resultSet.getInt("CARDINALITY")
             val pages           = resultSet.getInt("PAGES")
             val filterCondition = resultSet.getString("FILTER_CONDITION")
-            builder += s"$tableCat, $tableSchem, $tableName, $nonUnique, $indexQualifier, $indexName, $typed, $ordinalPosition, $columnName, $ascOrDesc, $cardinality, $pages, $filterCondition"
+            builder += s"$tableCat, $tableSchem, $tableName, $nonUnique, $indexQualifier, $indexName, $typed, $ordinalPosition, $columnName, $ascOrDesc, $pages, $filterCondition"
           builder.result()
       },
       Vector(
-        "connector_test, null, tax, false, null, PRIMARY, 3, 1, id, A, 3, 0, null"
+        "connector_test, null, tax, false, null, PRIMARY, 3, 1, id, A, 0, null"
       )
     )
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Since MySQL generates cardinality values based on statistics, they may not be accurate.

> MySQL generates the index cardinality based on statistics stored as integers, therefore, the value may not be necessarily > exact.

https://www.mysqltutorial.org/mysql-index/mysql-index-cardinality

This is why tests sometimes fail. Testing with unstable elements is a waste of time and effort, and there should be no need to check cardinality values if you know you can get data.

```
==> X ldbc.tests.LdbcDatabaseMetaDataTest.ldbc: getIndexInfo  0.011s munit.ComparisonFailException: /home/runner/work/ldbc/ldbc/tests/src/test/scala/ldbc/tests/DatabaseMetaDataTest.scala:1782
1781:      )
1782:    )
1783:  }
values are not the same
=> Obtained
Vector(
  "connector_test, null, tax, false, null, PRIMARY, 3, 1, id, A, 2, 0, null"
)
=> Diff (- obtained, + expected)
 Vector(
-  "connector_test, null, tax, false, null, PRIMARY, 3, 1, id, A, 2, 0, null"
+  "connector_test, null, tax, false, null, PRIMARY, 3, 1, id, A, 3, 0, null"
 )
```

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
