### PR TITLE
Refactor/2024 12 migrate table name designation to derived

### DIFF
--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -93,4 +93,7 @@ case class City(
   countryCode: String,
   district:    String,
   population:  Int
-) derives Table
+)
+
+object City:
+  given Table[City] = Table.derived[City]("city")

--- a/benchmark/src/main/scala/benchmark/wrapper/ldbc/Insert.scala
+++ b/benchmark/src/main/scala/benchmark/wrapper/ldbc/Insert.scala
@@ -56,7 +56,7 @@ class Insert:
 
     records = NonEmptyList.fromListUnsafe((1 to len).map(num => (num, s"record$num")).toList)
 
-    query = TableQuery[Test]("ldbc_wrapper_query_test")
+    query = TableQuery[Test]
 
   @Param(Array("10"))
   var len: Int = uninitialized
@@ -82,4 +82,6 @@ class Insert:
       }
       .unsafeRunSync()
 
-case class Test(c0: Option[Int], c1: Int, c2: String) derives Table
+case class Test(c0: Option[Int], c1: Int, c2: String)
+object Test:
+  given Table[Test] = Table.derived[Test]("ldbc_wrapper_query_test")

--- a/benchmark/src/main/scala/benchmark/wrapper/ldbc/Select.scala
+++ b/benchmark/src/main/scala/benchmark/wrapper/ldbc/Select.scala
@@ -46,7 +46,7 @@ class Select:
 
     connection = Resource.make(datasource.getConnection)(_.close())
 
-    query = TableQuery[City]("city")
+    query = TableQuery[City]
 
   @Param(Array("10", "100", "1000", "2000", "4000"))
   var len: Int = uninitialized

--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
@@ -22,16 +22,6 @@ trait SharedTable extends Dynamic:
 
   def columns: List[Column[?]]
 
-  /**
-   * Function for setting table names.
-   *
-   * @param name
-   * Table name
-   * @return
-   * Table with table name
-   */
-  def setName(name: String): Self
-
 trait Table[P] extends SharedTable, AbstractTable[P]:
 
   override type Self = Table[P]
@@ -67,12 +57,6 @@ object Table:
     extends Table[P]:
 
     override def statement: String = $name
-
-    override def setName(name: String): Self =
-      this.copy(
-        $name   = name,
-        columns = columns.map(column => column.as(s"$name.${ column.name }"))
-      )
 
     override def * : Column[P] =
       val decoder: Decoder[P] = new Decoder[P]((resultSet, prefix) =>
@@ -246,8 +230,3 @@ object Table:
     ) extends Opt[P]:
 
       override def statement: String = $name
-
-      override def setName(name: String): Self = this.copy(
-        $name   = name,
-        columns = columns.map(column => column.as(s"$name.${ column.name }"))
-      )

--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
@@ -75,7 +75,7 @@ object Table:
         Some(columns.map(column => s"${ column.name } = ?").mkString(", "))
       )
 
-  inline def derived[P <: Product]: Table[P] = ${ derivedImpl[P] }
+  inline def derived[P <: Product]:               Table[P] = ${ derivedImpl[P] }
   inline def derived[P <: Product](name: String): Table[P] = ${ derivedWithNameImpl[P]('name) }
 
   private def derivedImpl[P <: Product](using
@@ -142,8 +142,8 @@ object Table:
     }
 
   private def derivedWithNameImpl[P <: Product](name: Expr[String])(using
-                                                                    quotes: Quotes,
-                                                                    tpe:    Type[P]
+    quotes: Quotes,
+    tpe:    Type[P]
   ): Expr[Table[P]] =
 
     import quotes.reflect.*
@@ -154,7 +154,7 @@ object Table:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val mirror = Expr.summon[Mirror.ProductOf[P]].getOrElse {
       report.errorAndAbort(s"Mirror for type $tpe not found")

--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/TableQuery.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/TableQuery.scala
@@ -67,9 +67,3 @@ object TableQuery:
     mirror: Mirror.ProductOf[P]
   ): AbstractTableQuery[Table[P], Table.Opt[P]] =
     TableQueryImpl[Table[P], P](table, table.*, table.$name, List.empty)
-
-  def apply[P <: Product](
-    name: String
-  )(using table: Table[P], mirror: Mirror.ProductOf[P]): AbstractTableQuery[Table[P], Table.Opt[P]] =
-    val alias = table.setName(name)
-    TableQueryImpl[Table[P], P](alias, alias.*, alias.$name, List.empty)

--- a/tests/src/main/scala/ldbc/tests/model/City.scala
+++ b/tests/src/main/scala/ldbc/tests/model/City.scala
@@ -18,7 +18,11 @@ case class City(
   countryCode:      String,
   district:         String,
   population:       Int
-) derives Table
+)
+
+object City:
+
+  given Table[City] = Table.derived[City]("city")
 
 class CityTable extends SchemaTable[City]("city"):
 

--- a/tests/src/main/scala/ldbc/tests/model/Country.scala
+++ b/tests/src/main/scala/ldbc/tests/model/Country.scala
@@ -47,7 +47,7 @@ object Country:
 
   given Decoder.Elem[Continent] =
     Decoder.Elem.mapping[String, Continent](str => Continent.valueOf(str.replace(" ", "_")))
-    
+
   given Table[Country] = Table.derived[Country]("country")
 
 class CountryTable extends SchemaTable[Country]("country"):

--- a/tests/src/main/scala/ldbc/tests/model/Country.scala
+++ b/tests/src/main/scala/ldbc/tests/model/Country.scala
@@ -27,7 +27,7 @@ case class Country(
   headOfState:    Option[String],
   capital:        Option[Int],
   code2:          String
-) derives Table
+)
 
 object Country:
 
@@ -47,6 +47,8 @@ object Country:
 
   given Decoder.Elem[Continent] =
     Decoder.Elem.mapping[String, Continent](str => Continent.valueOf(str.replace(" ", "_")))
+    
+  given Table[Country] = Table.derived[Country]("country")
 
 class CountryTable extends SchemaTable[Country]("country"):
 

--- a/tests/src/main/scala/ldbc/tests/model/CountryLanguage.scala
+++ b/tests/src/main/scala/ldbc/tests/model/CountryLanguage.scala
@@ -16,7 +16,7 @@ case class CountryLanguage(
   language:    String,
   isOfficial:  CountryLanguage.IsOfficial,
   percentage:  BigDecimal
-) derives Table
+)
 
 object CountryLanguage:
 
@@ -30,6 +30,8 @@ object CountryLanguage:
 
   given Decoder.Elem[IsOfficial] =
     Decoder.Elem.mapping[String, IsOfficial](str => IsOfficial.valueOf(str))
+
+  given Table[CountryLanguage] = Table.derived[CountryLanguage]("countrylanguage")
 
 class CountryLanguageTable extends SchemaTable[CountryLanguage]("countrylanguage"):
 

--- a/tests/src/main/scala/ldbc/tests/model/GovernmentOffice.scala
+++ b/tests/src/main/scala/ldbc/tests/model/GovernmentOffice.scala
@@ -16,7 +16,11 @@ case class GovernmentOffice(
   @Column("CityID") cityId: Int,
   name:                     String,
   establishmentDate:        Option[LocalDate]
-) derives Table
+)
+
+object GovernmentOffice:
+  
+  given Table[GovernmentOffice] = Table.derived[GovernmentOffice]("government_office")
 
 class GovernmentOfficeTable extends SchemaTable[GovernmentOffice]("government_office"):
 

--- a/tests/src/main/scala/ldbc/tests/model/GovernmentOffice.scala
+++ b/tests/src/main/scala/ldbc/tests/model/GovernmentOffice.scala
@@ -19,7 +19,7 @@ case class GovernmentOffice(
 )
 
 object GovernmentOffice:
-  
+
   given Table[GovernmentOffice] = Table.derived[GovernmentOffice]("government_office")
 
 class GovernmentOfficeTable extends SchemaTable[GovernmentOffice]("government_office"):

--- a/tests/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
+++ b/tests/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
@@ -58,10 +58,10 @@ trait TableQuerySelectConnectionTest extends CatsEffectSuite:
   def prefix:     "jdbc" | "ldbc"
   def connection: Resource[IO, Connection[IO]]
 
-  private final val country          = TableQuery[Country]("country")
-  private final val city             = TableQuery[City]("city")
-  private final val countryLanguage  = TableQuery[CountryLanguage]("countrylanguage")
-  private final val governmentOffice = TableQuery[GovernmentOffice]("government_office")
+  private final val country          = TableQuery[Country]
+  private final val city             = TableQuery[City]
+  private final val countryLanguage  = TableQuery[CountryLanguage]
+  private final val governmentOffice = TableQuery[GovernmentOffice]
 
   test(
     "The results of all cases retrieved are transformed into a model, and the number of cases matches the specified value."

--- a/tests/src/test/scala/ldbc/tests/TableQueryUpdateConnectionTest.scala
+++ b/tests/src/test/scala/ldbc/tests/TableQueryUpdateConnectionTest.scala
@@ -59,9 +59,9 @@ trait TableQueryUpdateConnectionTest extends CatsEffectSuite:
   def prefix:     "jdbc" | "ldbc"
   def connection: Resource[IO, Connection[IO]]
 
-  private final val country         = TableQuery[Country]("country")
-  private final val city            = TableQuery[City]("city")
-  private final val countryLanguage = TableQuery[CountryLanguage]("countrylanguage")
+  private final val country         = TableQuery[Country]
+  private final val city            = TableQuery[City]
+  private final val countryLanguage = TableQuery[CountryLanguage]
 
   private def code(index: Int): String = prefix match
     case "jdbc" => s"J$index"


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

The method of specifying the table name using query builder has been changed from passing it as an argument of TableQuery to passing it as an argument of Table's derived.

**Before**

```scala
case class City(
  id: Int,
  name:             String,
  countryCode:      String,
  district:         String,
  population:       Int
) derives Table

val table = TableQuery[Test]("city")
```

**After**

```scala
case class City(
  id: Int,
  name:             String,
  countryCode:      String,
  district:         String,
  population:       Int
)

object City:
  given Table[City] = Table.derived[City]("city")
```

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
