### PR TITLE
Fixed Encoder fold use summonAll

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
@@ -93,14 +93,4 @@ object Encoder:
     case h *: EmptyTuple => Encoder[h] *: EmptyTuple
     case h *: t          => Encoder[h] *: MapToTuple[t]
 
-  inline def infer[T]: Encoder[T] =
-    summonFrom[Encoder[T]] {
-      case parameter: Encoder[T] => parameter
-      case _                     => error("Parameter cannot be inferred")
-    }
-
-  inline def fold[T]: MapToTuple[T] =
-    inline erasedValue[T] match
-      case _: EmptyTuple        => EmptyTuple
-      case _: (h *: EmptyTuple) => infer[h] *: EmptyTuple
-      case _: (h *: t)          => infer[h] *: fold[t]
+  inline def fold[T]: MapToTuple[T] = summonAll[MapToTuple[T]]


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Make the error message at the time of the Encoder derivation easy to understand.

In addition, the use of erasedValue and summonFrom was changed because summonAll can be used to complete the process.

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
