### PR TITLE
Bugfix/2024 12 fixed single column insert

### DIFF
--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
@@ -10,6 +10,7 @@ import scala.annotation.targetName
 
 import ldbc.dsl.{ Parameter, SQL }
 import ldbc.dsl.codec.Encoder
+import ldbc.statement.interpreter.ToTuple
 
 /**
  * Trait for building Statements to be added.
@@ -89,7 +90,7 @@ object Insert:
           case h               => h *: EmptyTuple
         }
         .flatMap(
-          _.zip(Encoder.fold[B]).toList
+          _.zip(Encoder.fold[ToTuple[B]]).toList
             .map {
               case (value, encoder) => Parameter.Dynamic(value)(using encoder.asInstanceOf[Encoder[Any]])
             }

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
@@ -13,6 +13,7 @@ import scala.annotation.targetName
 import ldbc.dsl.Parameter
 import ldbc.dsl.codec.Encoder
 import ldbc.statement.internal.QueryConcat
+import ldbc.statement.interpreter.ToTuple
 
 /**
  * Trait for constructing SQL Statement from Table information.
@@ -62,11 +63,6 @@ trait TableQuery[A, O]:
    */
   def selectAll: Select[A, Entity] =
     Select(table, column, s"SELECT ${ column.alias.getOrElse(column.name) } FROM $name", params)
-
-  protected type ToTuple[T] <: Tuple = T match
-    case h *: EmptyTuple => Tuple1[h]
-    case h *: t          => h *: ToTuple[t]
-    case _               => Tuple1[T]
 
   /**
    * Method to construct a query to insert a table.

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/interpreter/ToTuple.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/interpreter/ToTuple.scala
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.statement.interpreter
+
+type ToTuple[T] <: Tuple = T match
+  case h *: EmptyTuple => Tuple1[h]
+  case h *: t => h *: ToTuple[t]
+  case _ => Tuple1[T]

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/interpreter/ToTuple.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/interpreter/ToTuple.scala
@@ -8,5 +8,5 @@ package ldbc.statement.interpreter
 
 type ToTuple[T] <: Tuple = T match
   case h *: EmptyTuple => Tuple1[h]
-  case h *: t => h *: ToTuple[t]
-  case _ => Tuple1[T]
+  case h *: t          => h *: ToTuple[t]
+  case _               => Tuple1[T]


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Fixed an issue where an Insert statement with a single column would result in a compile error.

```scala
query.insertInto(_.id).values(1)
```

```shell
[error] 32 |    query.insertInto(_.id).values(1)
[error]    |                           ^
[error]    |       Tuple element types must be known at compile time
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from Encoder.scala:96
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from Encoder.scala:96
[error]     ----------------------------------------------------------------------------
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
