### PR TITLE
Feature/2024 12 create codec

### DIFF
--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -69,7 +69,7 @@ object Model20:
       Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
       Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
       Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
-    ).to[Model20]
+  ).to[Model20]
 
 case class Model25(
   c1:  Int,

--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -17,8 +17,7 @@ case class Model1(
 ) derives Table
 
 object Model1:
-  given Encoder[Model1] = Encoder[Int].to[Model1]
-  given Decoder[Model1] = Decoder[Int].to[Model1]
+  given Codec[Model1] = (Codec[Int]).to[Model1]
 
 case class Model5(
   c1: Int,
@@ -65,18 +64,12 @@ case class Model20(
 ) derives Table
 
 object Model20:
-  given Encoder[Model20] = (
-    Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int]
-  ).to[Model20]
-  given Decoder[Model20] = (
-    Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int]
-  ).to[Model20]
+  given Codec[Model20] = (
+    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
+    ).to[Model20]
 
 case class Model25(
   c1:  Int,
@@ -107,19 +100,12 @@ case class Model25(
 ) derives Table
 
 object Model25:
-  given Encoder[Model25] = (
-    Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *:
-      Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int] *: Encoder[Int]
-  ).to[Model25]
-  given Decoder[Model25] = (
-    Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *:
-      Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int] *: Decoder[Int]
+  given Codec[Model25] = (
+    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
   ).to[Model25]
 
 case class City(

--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -17,7 +17,7 @@ case class Model1(
 ) derives Table
 
 object Model1:
-  given Codec[Model1] = (Codec[Int]).to[Model1]
+  given Codec[Model1] = Codec[Int].to[Model1]
 
 case class Model5(
   c1: Int,
@@ -64,12 +64,9 @@ case class Model20(
 ) derives Table
 
 object Model20:
-  given Codec[Model20] = (
-    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
-  ).to[Model20]
+  given Codec[Model20] =
+    Codec[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]
+      .to[Model20]
 
 case class Model25(
   c1:  Int,
@@ -100,13 +97,35 @@ case class Model25(
 ) derives Table
 
 object Model25:
-  given Codec[Model25] = (
-    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
-      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
-  ).to[Model25]
+  given Codec[Model25] = Codec[
+    (
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int,
+      Int
+    )
+  ].to[Model25]
 
 case class City(
   id:          Int,

--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -64,9 +64,12 @@ case class Model20(
 ) derives Table
 
 object Model20:
-  given Codec[Model20] =
-    Codec[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)]
-      .to[Model20]
+  given Codec[Model20] = (
+    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
+  ).to[Model20]
 
 case class Model25(
   c1:  Int,
@@ -97,35 +100,13 @@ case class Model25(
 ) derives Table
 
 object Model25:
-  given Codec[Model25] = Codec[
-    (
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int,
-      Int
-    )
-  ].to[Model25]
+  given Codec[Model25] = (
+    Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *:
+      Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int] *: Codec[Int]
+  ).to[Model25]
 
 case class City(
   id:          Int,

--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/TableModelGenerator.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/TableModelGenerator.scala
@@ -148,7 +148,6 @@ private[ldbc] object TableModelGenerator:
         Some(s"""enum $enumName extends model.Enum:
            |    case ${ types.mkString(", ") }
            |  object $enumName extends model.EnumDataType[$enumName]:
-           |    given ldbc.dsl.codec.Decoder[$enumName] = ldbc.dsl.codec.Decoder[Int].map($enumName.fromOrdinal)
-           |    given ldbc.dsl.codec.Encoder[$enumName] = ldbc.dsl.codec.Encoder[Int].contramap(_.ordinal)
+           |    given ldbc.dsl.codec.Codec[$enumName] = ldbc.dsl.codec.Codec[Int].imap($enumName.fromOrdinal)(_.ordinal)
            |""".stripMargin)
       case _ => None

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Parameter.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Parameter.scala
@@ -48,5 +48,5 @@ object Parameter:
       case Encoder.Encoded.Success(list) =>
         list match
           case head :: Nil => Dynamic.Success(head)
-          case _ => Dynamic.Failure(List("Multiple values are not allowed"))
+          case _           => Dynamic.Failure(List("Multiple values are not allowed"))
       case Encoder.Encoded.Failure(errors) => Dynamic.Failure(errors.toList)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -157,6 +157,3 @@ object Codec extends TwiddleSyntax[Codec]:
 
   given [P <: Product](using mirror: Mirror.ProductOf[P], codec: Codec[mirror.MirroredElemTypes]): Codec[P] =
     codec.to[P]
-
-  given [A]: Conversion[Codec[A], Encoder[A]] = _.asEncoder
-  given [A]: Conversion[Codec[A], Decoder[A]] = _.asDecoder

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -30,123 +30,127 @@ trait Codec[A] extends Encoder[A], Decoder[A]:
     private val pe = self.asEncoder product fb.asEncoder
     private val pd = self.asDecoder product fb.asDecoder
 
-    override def offset: Int = self.offset + fb.offset
-    override def encode(value: (A, B)): Encoder.Encoded = pe.encode(value)
-    override def decode(resultSet: ResultSet, index: Int): (A, B) = pd.decode(resultSet, index)
+    override def offset:                                   Int             = self.offset + fb.offset
+    override def encode(value:     (A, B)):                Encoder.Encoded = pe.encode(value)
+    override def decode(resultSet: ResultSet, index: Int): (A, B)          = pd.decode(resultSet, index)
 
   /** Contramap inputs from, and map outputs to, a new type `B`, yielding a `Codec[B]`. */
   def imap[B](f: A => B)(g: B => A): Codec[B] = new Codec[B]:
-    override def offset: Int = self.offset
-    override def encode(value: B): Encoder.Encoded = self.encode(g(value))
-    override def decode(resultSet: ResultSet, index: Int): B = f(self.decode(resultSet, index))
+    override def offset:                                   Int             = self.offset
+    override def encode(value:     B):                     Encoder.Encoded = self.encode(g(value))
+    override def decode(resultSet: ResultSet, index: Int): B               = f(self.decode(resultSet, index))
 
   /** Lift this `Codec` into `Option`, where `None` is mapped to and from a vector of `NULL`. */
   override def opt: Codec[Option[A]] = new Codec[Option[A]]:
     override def offset: Int = self.offset
-    override def encode(value: Option[A]): Encoder.Encoded = value.fold(Encoder.Encoded.success(List(None)))(self.encode)
+    override def encode(value: Option[A]): Encoder.Encoded =
+      value.fold(Encoder.Encoded.success(List(None)))(self.encode)
     override def decode(resultSet: ResultSet, index: Int): Option[A] =
       val value = self.decode(resultSet, index)
       if resultSet.wasNull() then None else Some(value)
 
 object Codec extends TwiddleSyntax[Codec]:
-  
+
   def apply[A](using codec: Codec[A]): Codec[A] = codec
   def one[A](using encoder: Encoder[A], decoder: Decoder[A]): Codec[A] = new Codec[A]:
-    override def offset: Int = decoder.offset
-    override def encode(value: A): Encoder.Encoded = encoder.encode(value)
-    override def decode(resultSet: ResultSet, index: Int): A = decoder.decode(resultSet, index)
+    override def offset:                                   Int             = decoder.offset
+    override def encode(value:     A):                     Encoder.Encoded = encoder.encode(value)
+    override def decode(resultSet: ResultSet, index: Int): A               = decoder.decode(resultSet, index)
 
   given InvariantSemigroupal[Codec] with
-    override def imap[A, B](fa: Codec[A])(f: A => B)(g: B => A): Codec[B] = fa.imap(f)(g)
-    override def product[A, B](fa: Codec[A], fb: Codec[B]): Codec[(A, B)] = fa product fb
+    override def imap[A, B](fa:    Codec[A])(f:  A => B)(g: B => A): Codec[B]      = fa.imap(f)(g)
+    override def product[A, B](fa: Codec[A], fb: Codec[B]):          Codec[(A, B)] = fa product fb
 
   given Codec[Boolean] with
-    override def offset: Int = 1
-    override def encode(value: Boolean): Encoder.Encoded = Encoder[Boolean].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Boolean = Decoder[Boolean].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Boolean):               Encoder.Encoded = Encoder[Boolean].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Boolean         = Decoder[Boolean].decode(resultSet, index)
 
   given Codec[Byte] with
-    override def offset: Int = 1
-    override def encode(value: Byte): Encoder.Encoded = Encoder[Byte].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Byte = Decoder[Byte].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Byte):                  Encoder.Encoded = Encoder[Byte].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Byte            = Decoder[Byte].decode(resultSet, index)
 
   given Codec[Short] with
-    override def offset: Int = 1
-    override def encode(value: Short): Encoder.Encoded = Encoder[Short].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Short = Decoder[Short].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Short):                 Encoder.Encoded = Encoder[Short].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Short           = Decoder[Short].decode(resultSet, index)
 
   given Codec[Int] with
-    override def offset: Int = 1
-    override def encode(value: Int): Encoder.Encoded = Encoder[Int].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Int = Decoder[Int].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Int):                   Encoder.Encoded = Encoder[Int].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Int             = Decoder[Int].decode(resultSet, index)
 
   given Codec[Long] with
-    override def offset: Int = 1
-    override def encode(value: Long): Encoder.Encoded = Encoder[Long].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Long = Decoder[Long].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Long):                  Encoder.Encoded = Encoder[Long].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Long            = Decoder[Long].decode(resultSet, index)
 
   given Codec[Float] with
-    override def offset: Int = 1
-    override def encode(value: Float): Encoder.Encoded = Encoder[Float].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Float = Decoder[Float].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Float):                 Encoder.Encoded = Encoder[Float].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Float           = Decoder[Float].decode(resultSet, index)
 
   given Codec[Double] with
-    override def offset: Int = 1
-    override def encode(value: Double): Encoder.Encoded = Encoder[Double].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Double = Decoder[Double].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Double):                Encoder.Encoded = Encoder[Double].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Double          = Decoder[Double].decode(resultSet, index)
 
   given Codec[BigDecimal] with
-    override def offset: Int = 1
+    override def offset:                    Int             = 1
     override def encode(value: BigDecimal): Encoder.Encoded = Encoder[BigDecimal].encode(value)
     override def decode(resultSet: ResultSet, index: Int): BigDecimal = Decoder[BigDecimal].decode(resultSet, index)
 
   given Codec[String] with
-    override def offset: Int = 1
-    override def encode(value: String): Encoder.Encoded = Encoder[String].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): String = Decoder[String].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     String):                Encoder.Encoded = Encoder[String].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): String          = Decoder[String].decode(resultSet, index)
 
   given Codec[Array[Byte]] with
-    override def offset: Int = 1
+    override def offset:                     Int             = 1
     override def encode(value: Array[Byte]): Encoder.Encoded = Encoder[Array[Byte]].encode(value)
     override def decode(resultSet: ResultSet, index: Int): Array[Byte] = Decoder[Array[Byte]].decode(resultSet, index)
 
   given Codec[LocalTime] with
-    override def offset: Int = 1
-    override def encode(value: LocalTime): Encoder.Encoded = Encoder[LocalTime].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalTime = Decoder[LocalTime].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     LocalTime):             Encoder.Encoded = Encoder[LocalTime].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): LocalTime       = Decoder[LocalTime].decode(resultSet, index)
 
   given Codec[LocalDate] with
-    override def offset: Int = 1
-    override def encode(value: LocalDate): Encoder.Encoded = Encoder[LocalDate].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalDate = Decoder[LocalDate].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     LocalDate):             Encoder.Encoded = Encoder[LocalDate].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): LocalDate       = Decoder[LocalDate].decode(resultSet, index)
 
   given Codec[LocalDateTime] with
-    override def offset: Int = 1
+    override def offset:                       Int             = 1
     override def encode(value: LocalDateTime): Encoder.Encoded = Encoder[LocalDateTime].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalDateTime = Decoder[LocalDateTime].decode(resultSet, index)
+    override def decode(resultSet: ResultSet, index: Int): LocalDateTime =
+      Decoder[LocalDateTime].decode(resultSet, index)
 
   given Codec[Year] with
-    override def offset: Int = 1
-    override def encode(value: Year): Encoder.Encoded = Encoder[Year].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Year = Decoder[Year].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Year):                  Encoder.Encoded = Encoder[Year].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Year            = Decoder[Year].decode(resultSet, index)
 
   given Codec[YearMonth] with
-    override def offset: Int = 1
-    override def encode(value: YearMonth): Encoder.Encoded = Encoder[YearMonth].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): YearMonth = Decoder[YearMonth].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     YearMonth):             Encoder.Encoded = Encoder[YearMonth].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): YearMonth       = Decoder[YearMonth].decode(resultSet, index)
 
   given Codec[BigInt] with
-    override def offset: Int = 1
-    override def encode(value: BigInt): Encoder.Encoded = Encoder[BigInt].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): BigInt = Decoder[BigInt].decode(resultSet, index)
-  
-  given [A](using codec: Codec[A]): Codec[Option[A]] = codec.opt
-  
-  given [A, B](using ca: Codec[A], cb: Codec[B]): Codec[(A, B)] = ca product cb
-  
-  given [H, T <: Tuple](using dh: Codec[H], dt: Codec[T]): Codec[H *: T] = dh.product(dt).imap { case (h, t) => h *: t }(tuple => (tuple.head, tuple.tail))
+    override def offset:                                   Int             = 1
+    override def encode(value:     BigInt):                Encoder.Encoded = Encoder[BigInt].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): BigInt          = Decoder[BigInt].decode(resultSet, index)
 
-  given [P <: Product](using mirror: Mirror.ProductOf[P], codec: Codec[mirror.MirroredElemTypes]): Codec[P] = codec.to[P]
+  given [A](using codec: Codec[A]): Codec[Option[A]] = codec.opt
+
+  given [A, B](using ca: Codec[A], cb: Codec[B]): Codec[(A, B)] = ca product cb
+
+  given [H, T <: Tuple](using dh: Codec[H], dt: Codec[T]): Codec[H *: T] =
+    dh.product(dt).imap { case (h, t) => h *: t }(tuple => (tuple.head, tuple.tail))
+
+  given [P <: Product](using mirror: Mirror.ProductOf[P], codec: Codec[mirror.MirroredElemTypes]): Codec[P] =
+    codec.to[P]
 
   given [A]: Conversion[Codec[A], Encoder[A]] = _.asEncoder
   given [A]: Conversion[Codec[A], Decoder[A]] = _.asDecoder

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.dsl.codec
+
+import java.time.*
+
+import scala.deriving.Mirror
+
+import cats.InvariantSemigroupal
+
+import org.typelevel.twiddles.TwiddleSyntax
+
+import ldbc.sql.ResultSet
+
+trait Codec[A] extends Encoder[A], Decoder[A]:
+  self =>
+
+  /** Forget this value is a `Codec` and treat it as an `Encoder`. */
+  def asEncoder: Encoder[A] = this
+
+  /** Forget this value is a `Codec` and treat it as a `Decoder`. */
+  def asDecoder: Decoder[A] = this
+
+  /** `Codec` is semigroupal: a pair of codecs make a codec for a pair. */
+  def product[B](fb: Codec[B]): Codec[(A, B)] = new Codec[(A, B)]:
+    private val pe = self.asEncoder product fb.asEncoder
+    private val pd = self.asDecoder product fb.asDecoder
+
+    override def offset: Int = self.offset + fb.offset
+    override def encode(value: (A, B)): Encoder.Encoded = pe.encode(value)
+    override def decode(resultSet: ResultSet, index: Int): (A, B) = pd.decode(resultSet, index)
+
+  /** Contramap inputs from, and map outputs to, a new type `B`, yielding a `Codec[B]`. */
+  def imap[B](f: A => B)(g: B => A): Codec[B] = new Codec[B]:
+    override def offset: Int = self.offset
+    override def encode(value: B): Encoder.Encoded = self.encode(g(value))
+    override def decode(resultSet: ResultSet, index: Int): B = f(self.decode(resultSet, index))
+
+  /** Lift this `Codec` into `Option`, where `None` is mapped to and from a vector of `NULL`. */
+  override def opt: Codec[Option[A]] = new Codec[Option[A]]:
+    override def offset: Int = self.offset
+    override def encode(value: Option[A]): Encoder.Encoded = value.fold(Encoder.Encoded.success(List(None)))(self.encode)
+    override def decode(resultSet: ResultSet, index: Int): Option[A] =
+      val value = self.decode(resultSet, index)
+      if resultSet.wasNull() then None else Some(value)
+
+object Codec extends TwiddleSyntax[Codec]:
+  
+  def apply[A](using codec: Codec[A]): Codec[A] = codec
+  def one[A](using encoder: Encoder[A], decoder: Decoder[A]): Codec[A] = new Codec[A]:
+    override def offset: Int = decoder.offset
+    override def encode(value: A): Encoder.Encoded = encoder.encode(value)
+    override def decode(resultSet: ResultSet, index: Int): A = decoder.decode(resultSet, index)
+
+  given InvariantSemigroupal[Codec] with
+    override def imap[A, B](fa: Codec[A])(f: A => B)(g: B => A): Codec[B] = fa.imap(f)(g)
+    override def product[A, B](fa: Codec[A], fb: Codec[B]): Codec[(A, B)] = fa product fb
+
+  given Codec[Boolean] with
+    override def offset: Int = 1
+    override def encode(value: Boolean): Encoder.Encoded = Encoder[Boolean].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Boolean = Decoder[Boolean].decode(resultSet, index)
+
+  given Codec[Byte] with
+    override def offset: Int = 1
+    override def encode(value: Byte): Encoder.Encoded = Encoder[Byte].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Byte = Decoder[Byte].decode(resultSet, index)
+
+  given Codec[Short] with
+    override def offset: Int = 1
+    override def encode(value: Short): Encoder.Encoded = Encoder[Short].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Short = Decoder[Short].decode(resultSet, index)
+
+  given Codec[Int] with
+    override def offset: Int = 1
+    override def encode(value: Int): Encoder.Encoded = Encoder[Int].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Int = Decoder[Int].decode(resultSet, index)
+
+  given Codec[Long] with
+    override def offset: Int = 1
+    override def encode(value: Long): Encoder.Encoded = Encoder[Long].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Long = Decoder[Long].decode(resultSet, index)
+
+  given Codec[Float] with
+    override def offset: Int = 1
+    override def encode(value: Float): Encoder.Encoded = Encoder[Float].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Float = Decoder[Float].decode(resultSet, index)
+
+  given Codec[Double] with
+    override def offset: Int = 1
+    override def encode(value: Double): Encoder.Encoded = Encoder[Double].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Double = Decoder[Double].decode(resultSet, index)
+
+  given Codec[BigDecimal] with
+    override def offset: Int = 1
+    override def encode(value: BigDecimal): Encoder.Encoded = Encoder[BigDecimal].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): BigDecimal = Decoder[BigDecimal].decode(resultSet, index)
+
+  given Codec[String] with
+    override def offset: Int = 1
+    override def encode(value: String): Encoder.Encoded = Encoder[String].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): String = Decoder[String].decode(resultSet, index)
+
+  given Codec[Array[Byte]] with
+    override def offset: Int = 1
+    override def encode(value: Array[Byte]): Encoder.Encoded = Encoder[Array[Byte]].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Array[Byte] = Decoder[Array[Byte]].decode(resultSet, index)
+
+  given Codec[LocalTime] with
+    override def offset: Int = 1
+    override def encode(value: LocalTime): Encoder.Encoded = Encoder[LocalTime].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): LocalTime = Decoder[LocalTime].decode(resultSet, index)
+
+  given Codec[LocalDate] with
+    override def offset: Int = 1
+    override def encode(value: LocalDate): Encoder.Encoded = Encoder[LocalDate].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): LocalDate = Decoder[LocalDate].decode(resultSet, index)
+
+  given Codec[LocalDateTime] with
+    override def offset: Int = 1
+    override def encode(value: LocalDateTime): Encoder.Encoded = Encoder[LocalDateTime].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): LocalDateTime = Decoder[LocalDateTime].decode(resultSet, index)
+
+  given Codec[Year] with
+    override def offset: Int = 1
+    override def encode(value: Year): Encoder.Encoded = Encoder[Year].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): Year = Decoder[Year].decode(resultSet, index)
+
+  given Codec[YearMonth] with
+    override def offset: Int = 1
+    override def encode(value: YearMonth): Encoder.Encoded = Encoder[YearMonth].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): YearMonth = Decoder[YearMonth].decode(resultSet, index)
+
+  given Codec[BigInt] with
+    override def offset: Int = 1
+    override def encode(value: BigInt): Encoder.Encoded = Encoder[BigInt].encode(value)
+    override def decode(resultSet: ResultSet, index: Int): BigInt = Decoder[BigInt].decode(resultSet, index)
+  
+  given [A](using codec: Codec[A]): Codec[Option[A]] = codec.opt
+  
+  given [A, B](using ca: Codec[A], cb: Codec[B]): Codec[(A, B)] = ca product cb
+  
+  given [H, T <: Tuple](using dh: Codec[H], dt: Codec[T]): Codec[H *: T] = dh.product(dt).imap { case (h, t) => h *: t }(tuple => (tuple.head, tuple.tail))
+
+  given [P <: Product](using mirror: Mirror.ProductOf[P], codec: Codec[mirror.MirroredElemTypes]): Codec[P] = codec.to[P]
+
+  given [A]: Conversion[Codec[A], Encoder[A]] = _.asEncoder
+  given [A]: Conversion[Codec[A], Decoder[A]] = _.asDecoder

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -16,6 +16,12 @@ import org.typelevel.twiddles.TwiddleSyntax
 
 import ldbc.sql.ResultSet
 
+/**
+ * Symmetric encoder and decoder of MySQL data to and from Scala types.
+ *
+ * @tparam A
+ *   Types handled in Scala
+ */
 trait Codec[A] extends Encoder[A], Decoder[A]:
   self =>
 

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -58,10 +58,6 @@ trait Codec[A] extends Encoder[A], Decoder[A]:
 object Codec extends TwiddleSyntax[Codec]:
 
   def apply[A](using codec: Codec[A]): Codec[A] = codec
-  def one[A](using encoder: Encoder[A], decoder: Decoder[A]): Codec[A] = new Codec[A]:
-    override def offset:                                   Int             = decoder.offset
-    override def encode(value:     A):                     Encoder.Encoded = encoder.encode(value)
-    override def decode(resultSet: ResultSet, index: Int): A               = decoder.decode(resultSet, index)
 
   given InvariantSemigroupal[Codec] with
     override def imap[A, B](fa:    Codec[A])(f:  A => B)(g: B => A): Codec[B]      = fa.imap(f)(g)
@@ -69,84 +65,82 @@ object Codec extends TwiddleSyntax[Codec]:
 
   given Codec[Boolean] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Boolean):               Encoder.Encoded = Encoder[Boolean].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Boolean         = Decoder[Boolean].decode(resultSet, index)
+    override def encode(value:     Boolean):               Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Boolean         = resultSet.getBoolean(index)
 
   given Codec[Byte] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Byte):                  Encoder.Encoded = Encoder[Byte].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Byte            = Decoder[Byte].decode(resultSet, index)
+    override def encode(value:     Byte):                  Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Byte            = resultSet.getByte(index)
 
   given Codec[Short] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Short):                 Encoder.Encoded = Encoder[Short].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Short           = Decoder[Short].decode(resultSet, index)
+    override def encode(value:     Short):                 Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Short           = resultSet.getShort(index)
 
   given Codec[Int] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Int):                   Encoder.Encoded = Encoder[Int].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Int             = Decoder[Int].decode(resultSet, index)
+    override def encode(value:     Int):                   Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Int             = resultSet.getInt(index)
 
   given Codec[Long] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Long):                  Encoder.Encoded = Encoder[Long].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Long            = Decoder[Long].decode(resultSet, index)
+    override def encode(value:     Long):                  Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Long            = resultSet.getLong(index)
 
   given Codec[Float] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Float):                 Encoder.Encoded = Encoder[Float].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Float           = Decoder[Float].decode(resultSet, index)
+    override def encode(value:     Float):                 Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Float           = resultSet.getFloat(index)
 
   given Codec[Double] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Double):                Encoder.Encoded = Encoder[Double].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Double          = Decoder[Double].decode(resultSet, index)
+    override def encode(value:     Double):                Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Double          = resultSet.getDouble(index)
 
   given Codec[BigDecimal] with
-    override def offset:                    Int             = 1
-    override def encode(value: BigDecimal): Encoder.Encoded = Encoder[BigDecimal].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): BigDecimal = Decoder[BigDecimal].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     BigDecimal):            Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): BigDecimal      = resultSet.getBigDecimal(index)
 
   given Codec[String] with
     override def offset:                                   Int             = 1
-    override def encode(value:     String):                Encoder.Encoded = Encoder[String].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): String          = Decoder[String].decode(resultSet, index)
+    override def encode(value:     String):                Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): String          = resultSet.getString(index)
 
   given Codec[Array[Byte]] with
-    override def offset:                     Int             = 1
-    override def encode(value: Array[Byte]): Encoder.Encoded = Encoder[Array[Byte]].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Array[Byte] = Decoder[Array[Byte]].decode(resultSet, index)
+    override def offset:                                   Int             = 1
+    override def encode(value:     Array[Byte]):           Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): Array[Byte]     = resultSet.getBytes(index)
 
   given Codec[LocalTime] with
     override def offset:                                   Int             = 1
-    override def encode(value:     LocalTime):             Encoder.Encoded = Encoder[LocalTime].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalTime       = Decoder[LocalTime].decode(resultSet, index)
+    override def encode(value:     LocalTime):             Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): LocalTime       = resultSet.getTime(index)
 
   given Codec[LocalDate] with
     override def offset:                                   Int             = 1
-    override def encode(value:     LocalDate):             Encoder.Encoded = Encoder[LocalDate].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalDate       = Decoder[LocalDate].decode(resultSet, index)
+    override def encode(value:     LocalDate):             Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): LocalDate       = resultSet.getDate(index)
 
   given Codec[LocalDateTime] with
-    override def offset:                       Int             = 1
-    override def encode(value: LocalDateTime): Encoder.Encoded = Encoder[LocalDateTime].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): LocalDateTime =
-      Decoder[LocalDateTime].decode(resultSet, index)
-
-  given Codec[Year] with
     override def offset:                                   Int             = 1
-    override def encode(value:     Year):                  Encoder.Encoded = Encoder[Year].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): Year            = Decoder[Year].decode(resultSet, index)
+    override def encode(value:     LocalDateTime):         Encoder.Encoded = Encoder.Encoded.success(List(value))
+    override def decode(resultSet: ResultSet, index: Int): LocalDateTime   = resultSet.getTimestamp(index)
 
-  given Codec[YearMonth] with
-    override def offset:                                   Int             = 1
-    override def encode(value:     YearMonth):             Encoder.Encoded = Encoder[YearMonth].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): YearMonth       = Decoder[YearMonth].decode(resultSet, index)
+  given [A](using codec: Codec[Int]): Codec[Year] =
+    codec.imap(Year.of)(_.getValue)
 
-  given Codec[BigInt] with
+  given [A](using codec: Codec[String]): Codec[YearMonth] =
+    codec.imap(YearMonth.parse)(_.toString)
+
+  given [A](using codec: Codec[String]): Codec[BigInt] =
+    codec.imap(str => if str == null then null else BigInt(str))(_.toString)
+
+  given Codec[None.type] with
     override def offset:                                   Int             = 1
-    override def encode(value:     BigInt):                Encoder.Encoded = Encoder[BigInt].encode(value)
-    override def decode(resultSet: ResultSet, index: Int): BigInt          = Decoder[BigInt].decode(resultSet, index)
+    override def encode(value:     None.type):             Encoder.Encoded = Encoder.Encoded.success(List(None))
+    override def decode(resultSet: ResultSet, index: Int): None.type       = None
 
   given [A](using codec: Codec[A]): Codec[Option[A]] = codec.opt
 

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -17,7 +17,7 @@ import org.typelevel.twiddles.TwiddleSyntax
 import ldbc.sql.ResultSet
 
 /**
- * Class to get the DataType that matches the Scala type information from the ResultSet.
+ * Trait to get the DataType that matches the Scala type information from the ResultSet.
  *
  * @tparam A
  *   Scala types that match SQL DataType

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -6,6 +6,8 @@
 
 package ldbc.dsl.codec
 
+import scala.deriving.Mirror
+
 import cats.Applicative
 
 import org.typelevel.twiddles.TwiddleSyntax
@@ -68,3 +70,14 @@ object Decoder extends TwiddleSyntax[Decoder]:
       override def decode(resultSet: ResultSet, index: Int): A   = x
 
   given [A](using codec: Codec[A]): Decoder[A] = codec.asDecoder
+
+  given [A](using decoder: Decoder[A]): Decoder[Option[A]] = decoder.opt
+
+  given [A, B](using da: Decoder[A], db: Decoder[B]): Decoder[(A, B)] =
+    da.product(db)
+
+  given [H, T <: Tuple](using dh: Decoder[H], dt: Decoder[T]): Decoder[H *: T] =
+    dh.product(dt).map { case (h, t) => h *: t }
+
+  given [P <: Product](using mirror: Mirror.ProductOf[P], decoder: Decoder[mirror.MirroredElemTypes]): Decoder[P] =
+    decoder.to[P]

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Decoder.scala
@@ -6,10 +6,6 @@
 
 package ldbc.dsl.codec
 
-import java.time.*
-
-import scala.deriving.Mirror
-
 import cats.Applicative
 
 import org.typelevel.twiddles.TwiddleSyntax
@@ -71,36 +67,4 @@ object Decoder extends TwiddleSyntax[Decoder]:
       override def offset:                                   Int = 0
       override def decode(resultSet: ResultSet, index: Int): A   = x
 
-  given Decoder[String]        = (resultSet: ResultSet, index: Int) => resultSet.getString(index)
-  given Decoder[Boolean]       = (resultSet: ResultSet, index: Int) => resultSet.getBoolean(index)
-  given Decoder[Byte]          = (resultSet: ResultSet, index: Int) => resultSet.getByte(index)
-  given Decoder[Array[Byte]]   = (resultSet: ResultSet, index: Int) => resultSet.getBytes(index)
-  given Decoder[Short]         = (resultSet: ResultSet, index: Int) => resultSet.getShort(index)
-  given Decoder[Int]           = (resultSet: ResultSet, index: Int) => resultSet.getInt(index)
-  given Decoder[Long]          = (resultSet: ResultSet, index: Int) => resultSet.getLong(index)
-  given Decoder[Float]         = (resultSet: ResultSet, index: Int) => resultSet.getFloat(index)
-  given Decoder[Double]        = (resultSet: ResultSet, index: Int) => resultSet.getDouble(index)
-  given Decoder[LocalDate]     = (resultSet: ResultSet, index: Int) => resultSet.getDate(index)
-  given Decoder[LocalTime]     = (resultSet: ResultSet, index: Int) => resultSet.getTime(index)
-  given Decoder[LocalDateTime] = (resultSet: ResultSet, index: Int) => resultSet.getTimestamp(index)
-  given Decoder[BigDecimal]    = (resultSet: ResultSet, index: Int) => resultSet.getBigDecimal(index)
-
-  given (using decoder: Decoder[String]): Decoder[BigInt] =
-    decoder.map(str => if str == null then null else BigInt(str))
-
-  given (using decoder: Decoder[Int]): Decoder[Year] =
-    decoder.map(int => Year.of(int))
-
-  given (using decoder: Decoder[String]): Decoder[YearMonth] =
-    decoder.map(str => YearMonth.parse(str))
-
-  given [A](using decoder: Decoder[A]): Decoder[Option[A]] = decoder.opt
-
-  given [A, B](using da: Decoder[A], db: Decoder[B]): Decoder[(A, B)] =
-    da.product(db)
-
-  given [H, T <: Tuple](using dh: Decoder[H], dt: Decoder[T]): Decoder[H *: T] =
-    dh.product(dt).map { case (h, t) => h *: t }
-
-  given [P <: Product](using mirror: Mirror.ProductOf[P], decoder: Decoder[mirror.MirroredElemTypes]): Decoder[P] =
-    decoder.to[P]
+  given [A](using codec: Codec[A]): Decoder[A] = codec.asDecoder

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
@@ -8,8 +8,6 @@ package ldbc.dsl.codec
 
 import java.time.*
 
-import scala.deriving.Mirror
-
 import cats.ContravariantSemigroupal
 import cats.data.NonEmptyList
 import cats.syntax.all.*
@@ -58,82 +56,7 @@ object Encoder extends TwiddleSyntax[Encoder]:
     override def contramap[A, B](fa: Encoder[A])(f:  B => A):     Encoder[B]      = fa.contramap(f)
     override def product[A, B](fa:   Encoder[A], fb: Encoder[B]): Encoder[(A, B)] = fa.product(fb)
 
-  given Encoder[Boolean] with
-    override def encode(value: Boolean): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Byte] with
-    override def encode(value: Byte): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Short] with
-    override def encode(value: Short): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Int] with
-    override def encode(value: Int): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Long] with
-    override def encode(value: Long): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Float] with
-    override def encode(value: Float): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Double] with
-    override def encode(value: Double): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[BigDecimal] with
-    override def encode(value: BigDecimal): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[String] with
-    override def encode(value: String): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[Array[Byte]] with
-    override def encode(value: Array[Byte]): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[LocalTime] with
-    override def encode(value: LocalTime): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[LocalDate] with
-    override def encode(value: LocalDate): Encoded =
-      Encoded.success(List(value))
-
-  given Encoder[LocalDateTime] with
-    override def encode(value: LocalDateTime): Encoded =
-      Encoded.success(List(value))
-
-  given (using encoder: Encoder[String]): Encoder[Year] = encoder.contramap(_.toString)
-
-  given (using encoder: Encoder[String]): Encoder[YearMonth] = encoder.contramap(_.toString)
-
-  given (using encoder: Encoder[String]): Encoder[BigInt] = encoder.contramap(_.toString)
-
-  given Encoder[None.type] with
-    override def encode(value: None.type): Encoded =
-      Encoded.success(List(None))
-
-  given [A](using encoder: Encoder[A]): Encoder[Option[A]] with
-    override def encode(value: Option[A]): Encoded =
-      value match
-        case Some(value) => encoder.encode(value)
-        case None        => Encoded.success(List(None))
-
-  given [A, B](using ea: Encoder[A], eb: Encoder[B]): Encoder[(A, B)] =
-    ea.product(eb)
-
-  given [H, T <: Tuple](using eh: Encoder[H], et: Encoder[T]): Encoder[H *: T] =
-    eh.product(et).contramap { case h *: t => (h, t) }
-
-  given [P <: Product](using mirror: Mirror.ProductOf[P], encoder: Encoder[mirror.MirroredElemTypes]): Encoder[P] =
-    encoder.to[P]
+  given [A](using codec: Codec[A]): Encoder[A] = codec.asEncoder
 
   sealed trait Encoded:
     def product(that: Encoded): Encoded

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
@@ -8,6 +8,8 @@ package ldbc.dsl.codec
 
 import java.time.*
 
+import scala.deriving.Mirror
+
 import cats.ContravariantSemigroupal
 import cats.data.NonEmptyList
 import cats.syntax.all.*
@@ -57,6 +59,15 @@ object Encoder extends TwiddleSyntax[Encoder]:
     override def product[A, B](fa:   Encoder[A], fb: Encoder[B]): Encoder[(A, B)] = fa.product(fb)
 
   given [A](using codec: Codec[A]): Encoder[A] = codec.asEncoder
+
+  given [A, B](using ea: Encoder[A], eb: Encoder[B]): Encoder[(A, B)] =
+    ea.product(eb)
+
+  given [H, T <: Tuple](using eh: Encoder[H], et: Encoder[T]): Encoder[H *: T] =
+    eh.product(et).contramap { case h *: t => (h, t) }
+
+  given [P <: Product](using mirror: Mirror.ProductOf[P], encoder: Encoder[mirror.MirroredElemTypes]): Encoder[P] =
+    encoder.to[P]
 
   sealed trait Encoded:
     def product(that: Encoded): Encoded

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -24,7 +24,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   protected final def column[A](name: String, dataType: DataType[A])(using codec: Codec[A]): Column[A] =
     ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), List.empty)
 
-  protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using codec: Codec[A]): Column[A] =
+  protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using
+    codec: Codec[A]
+  ): Column[A] =
     ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), attributes.toList)
 
   /**

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -9,7 +9,7 @@ package ldbc.schema
 import scala.language.dynamics
 import scala.deriving.Mirror
 
-import ldbc.dsl.codec.{ Decoder, Encoder }
+import ldbc.dsl.codec.Codec
 import ldbc.statement.{ AbstractTable, Column }
 import ldbc.schema.interpreter.*
 import ldbc.schema.attribute.Attribute
@@ -18,20 +18,14 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
 
   type Column[A] = ldbc.statement.Column[A]
 
-  protected final def column[A](name: String)(using decoder: Decoder[A], encoder: Encoder[A]): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), decoder, encoder, None, List.empty)
+  protected final def column[A](name: String)(using codec: Codec[A]): Column[A] =
+    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, None, List.empty)
 
-  protected final def column[A](name: String, dataType: DataType[A])(using
-    decoder: Decoder[A],
-    encoder: Encoder[A]
-  ): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), decoder, encoder, Some(dataType), List.empty)
+  protected final def column[A](name: String, dataType: DataType[A])(using codec: Codec[A]): Column[A] =
+    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), List.empty)
 
-  protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using
-    decoder: Decoder[A],
-    encoder: Encoder[A]
-  ): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), decoder, encoder, Some(dataType), attributes.toList)
+  protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using codec: Codec[A]): Column[A] =
+    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), attributes.toList)
 
   /**
    * Methods for setting key information for tables.

--- a/tests/src/main/scala/ldbc/tests/model/Country.scala
+++ b/tests/src/main/scala/ldbc/tests/model/Country.scala
@@ -49,7 +49,7 @@ object Country:
       Codec[Option[Short]] *: Codec[Int] *: Codec[Option[BigDecimal]] *: Codec[Option[BigDecimal]] *:
       Codec[Option[BigDecimal]] *: Codec[String] *: Codec[String] *: Codec[Option[String]] *:
       Codec[Option[Int]] *: Codec[String]
-    ).to[Country]
+  ).to[Country]
   given Table[Country] = Table.derived[Country]("country")
 
 class CountryTable extends SchemaTable[Country]("country"):

--- a/tests/src/main/scala/ldbc/tests/model/Country.scala
+++ b/tests/src/main/scala/ldbc/tests/model/Country.scala
@@ -42,7 +42,7 @@ object Country:
 
     override def toString: String = value
 
-  given Codec[Continent] = Codec[String].imap(Continent.valueOf)(_.value)
+  given Codec[Continent] = Codec[String].imap(str => Continent.valueOf(str.replace(" ", "_")))(_.value)
 
   given Codec[Country] = (
     Codec[String] *: Codec[String] *: Codec[Continent] *: Codec[String] *: Codec[BigDecimal] *:

--- a/tests/src/main/scala/ldbc/tests/model/Country.scala
+++ b/tests/src/main/scala/ldbc/tests/model/Country.scala
@@ -7,7 +7,7 @@
 package ldbc.tests.model
 
 import ldbc.dsl.*
-import ldbc.dsl.codec.{ Encoder, Decoder }
+import ldbc.dsl.codec.Codec
 import ldbc.query.builder.Table
 import ldbc.schema.Table as SchemaTable
 
@@ -42,22 +42,14 @@ object Country:
 
     override def toString: String = value
 
-  given Encoder[Continent] = Encoder[String].contramap(_.value)
+  given Codec[Continent] = Codec[String].imap(Continent.valueOf)(_.value)
 
-  given Decoder[Continent] = Decoder[String].map(str => Continent.valueOf(str.replace(" ", "_")))
-
-  given Encoder[Country] = (
-    Encoder[String] *: Encoder[String] *: Encoder[Continent] *: Encoder[String] *: Encoder[BigDecimal] *:
-      Encoder[Option[Short]] *: Encoder[Int] *: Encoder[Option[BigDecimal]] *: Encoder[Option[BigDecimal]] *:
-      Encoder[Option[BigDecimal]] *: Encoder[String] *: Encoder[String] *: Encoder[Option[String]] *:
-      Encoder[Option[Int]] *: Encoder[String]
-  ).to[Country]
-  given Decoder[Country] = (
-    Decoder[String] *: Decoder[String] *: Decoder[Continent] *: Decoder[String] *: Decoder[BigDecimal] *:
-      Decoder[Option[Short]] *: Decoder[Int] *: Decoder[Option[BigDecimal]] *: Decoder[Option[BigDecimal]] *:
-      Decoder[Option[BigDecimal]] *: Decoder[String] *: Decoder[String] *: Decoder[Option[String]] *:
-      Decoder[Option[Int]] *: Decoder[String]
-  ).to[Country]
+  given Codec[Country] = (
+    Codec[String] *: Codec[String] *: Codec[Continent] *: Codec[String] *: Codec[BigDecimal] *:
+      Codec[Option[Short]] *: Codec[Int] *: Codec[Option[BigDecimal]] *: Codec[Option[BigDecimal]] *:
+      Codec[Option[BigDecimal]] *: Codec[String] *: Codec[String] *: Codec[Option[String]] *:
+      Codec[Option[Int]] *: Codec[String]
+    ).to[Country]
   given Table[Country] = Table.derived[Country]("country")
 
 class CountryTable extends SchemaTable[Country]("country"):

--- a/tests/src/main/scala/ldbc/tests/model/CountryLanguage.scala
+++ b/tests/src/main/scala/ldbc/tests/model/CountryLanguage.scala
@@ -7,7 +7,7 @@
 package ldbc.tests.model
 
 import ldbc.dsl.*
-import ldbc.dsl.codec.{ Encoder, Decoder }
+import ldbc.dsl.codec.Codec
 import ldbc.query.builder.Table
 import ldbc.schema.Table as SchemaTable
 
@@ -25,9 +25,7 @@ object CountryLanguage:
 
   object IsOfficial
 
-  given Encoder[IsOfficial] = Encoder[String].contramap(_.toString)
-
-  given Decoder[IsOfficial] = Decoder[String].map(IsOfficial.valueOf)
+  given Codec[IsOfficial] = Codec[String].imap(IsOfficial.valueOf)(_.toString)
 
   given Table[CountryLanguage] = Table.derived[CountryLanguage]("countrylanguage")
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

If both Encoder and Decoder were needed, each had to be defined. With this modification, a new Codec has been added, allowing Encoder and Decoder to be defined together.

```diff
enum Status:
  case Active, InActive

-given Encoder[Status] = Encoder[Boolean].contramap {
-  case Status.Active   => true
-  case Status.InActive => false
-}

-given Decoder[Status] = Decoder[Boolean].map {
-  case true  => Status.Active
-  case false => Status.InActive
-}

+given Codec[Status] = Codec[Boolean].imap {
+  case true => Status.Active
+  case false => Status.InActive
+} {
+  case Status.Active   => true
+  case Status.InActive => false
+}
```

It can also be used in place of a Decoder or Encoder by building a Codec.

```diff
-given Decoder[City] = (Decoder[Int] *: Decoder[String] *: Decoder[Int]).to[City]
+given Codec[City] = (Codec[Int] *: Codec[String] *: Codec[Int]).to[City]
```

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
