### PR TITLE
Refactor/2025 01 fixed dbio warning

### DIFF
--- a/tests/src/test/scala/ldbc/tests/DBIOTest.scala
+++ b/tests/src/test/scala/ldbc/tests/DBIOTest.scala
@@ -33,7 +33,7 @@ class DBIOTest extends CatsEffectSuite:
     val program = DBIO.pure[IO, Int](1)
     assertIO(
       connection.use { conn =>
-        program.execute(conn)
+        program.run(conn)
       },
       1
     )
@@ -45,7 +45,7 @@ class DBIOTest extends CatsEffectSuite:
     val program3 = program2.ap(program1)
     assertIO(
       connection.use { conn =>
-        program3.execute(conn)
+        program3.run(conn)
       },
       2
     )
@@ -56,7 +56,7 @@ class DBIOTest extends CatsEffectSuite:
     val program2 = program1.map(_ + 1)
     assertIO(
       connection.use { conn =>
-        program2.execute(conn)
+        program2.run(conn)
       },
       2
     )
@@ -67,7 +67,7 @@ class DBIOTest extends CatsEffectSuite:
     val program2 = program1.flatMap(n => DBIO.pure[IO, Int](n + 1))
     assertIO(
       connection.use { conn =>
-        program2.execute(conn)
+        program2.run(conn)
       },
       2
     )
@@ -78,7 +78,7 @@ class DBIOTest extends CatsEffectSuite:
     val program2 = program1.tailRecM[DBIO, String](_.map(n => Right(n.toString)))
     assertIO(
       connection.use { conn =>
-        program2.execute(conn)
+        program2.run(conn)
       },
       "1"
     )
@@ -88,7 +88,7 @@ class DBIOTest extends CatsEffectSuite:
     val program = DBIO.raiseError[IO, Int](new Exception("error"))
     interceptMessageIO[Exception]("error")(
       connection.use { conn =>
-        program.execute(conn)
+        program.run(conn)
       }
     )
   }
@@ -98,7 +98,7 @@ class DBIOTest extends CatsEffectSuite:
     val program2 = program1.handleErrorWith(e => DBIO.pure[IO, Int](0))
     assertIO(
       connection.use { conn =>
-        program2.execute(conn)
+        program2.run(conn)
       },
       0
     )
@@ -108,7 +108,7 @@ class DBIOTest extends CatsEffectSuite:
     val program = DBIO.pure[IO, Int](1)
     assertIO(
       connection.use { conn =>
-        program.attempt.execute(conn)
+        program.attempt.run(conn)
       },
       Right(1)
     )
@@ -118,7 +118,7 @@ class DBIOTest extends CatsEffectSuite:
     val program: DBIO[Int] = DBIO.raiseError[IO, Int](new Exception("error"))
     assertIOBoolean(
       connection.use { conn =>
-        program.attempt.execute(conn).map(_.isLeft)
+        program.attempt.run(conn).map(_.isLeft)
       }
     )
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

- Remove type parameter constraints from DBIO
- Renamed from execute function to run function
- Remove duplicate Functor implementations

## Fixes

Fixed a warning that occurred when updating to Scala 3.6.x series with the following pull request

https://github.com/takapi327/ldbc/pull/335

Relevant Actions: https://github.com/takapi327/ldbc/actions/runs/12562908297/job/35024021510?pr=335

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
