### PR TITLE
Bugfix/2025 01 table query macro error

### DIFF
--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/TableQuery.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/TableQuery.scala
@@ -12,7 +12,7 @@ import ldbc.dsl.Parameter
 import ldbc.dsl.codec.*
 import ldbc.statement.{ TableQuery as AbstractTableQuery, * }
 
-private[ldbc] case class TableQueryImpl[A <: SharedTable & AbstractTable[?], B <: Product](
+case class TableQueryImpl[A <: SharedTable & AbstractTable[?], B <: Product](
   table:  A,
   column: Column[AbstractTableQuery.Extract[A]],
   name:   String,
@@ -39,7 +39,7 @@ private[ldbc] case class TableQueryImpl[A <: SharedTable & AbstractTable[?], B <
     TableQueryOpt[A, Table.Opt[AbstractTableQuery.Extract[A]]](opt, opt.*, opt.$name, params)
       .asInstanceOf[AbstractTableQuery[A, Table.Opt[AbstractTableQuery.Extract[A]]]]
 
-private[ldbc] case class TableQueryOpt[A, O <: SharedTable](
+case class TableQueryOpt[A, O <: SharedTable](
   table:  O,
   column: Column[AbstractTableQuery.Extract[O]],
   name:   String,

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -40,7 +40,7 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
 
 object Table:
 
-  private[ldbc] case class Opt[T](
+  case class Opt[T](
     $name:   String,
     columns: List[Column[?]],
     *      : Column[Option[T]]

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/TableQuery.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/TableQuery.scala
@@ -11,7 +11,7 @@ import scala.quoted.*
 import ldbc.dsl.Parameter
 import ldbc.statement.{ TableQuery as AbstractTableQuery, * }
 
-private[ldbc] case class TableQueryImpl[A <: AbstractTable[?]](
+case class TableQueryImpl[A <: AbstractTable[?]](
   table:  A,
   column: Column[AbstractTableQuery.Extract[A]],
   name:   String,


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

TableQuery construction using macros in a location not under the ldbc package object causes a compile error.

```shell
[error] 10 |  protected final val survey: TableQuery[CityTable] = TableQuery[CityTable]
[error]    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^
[error]    |                                        Found:    ldbc.schema.Table.type
[error]    |                                        Required: ?{ Opt: ? }
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from TableQuery.scala:53
[error]     ----------------------------------------------------------------------------
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```

This problem occurred because the actual state of TableQuery constructed by the macro was `private[ldbc]` and its use was permitted only under the package of ldbc.

Eliminating the PRIVATE limitation eliminated this problem.

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
