### PR TITLE
Comparison operator compile error due to use of Opaque Type Alias

### DIFF
--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -143,7 +143,7 @@ trait Column[A]:
   @targetName("matchCondition")
   def ===[B](value: B)(using Encoder[B], A =:= Option[B]): MatchCondition[B] = _equals(value)
 
-  def orMore(value: A)(using Encoder[A]): OrMore[A] = OrMore(noBagQuotLabel, false, value)
+  def orMore(value:    A)(using Encoder[A]):                  OrMore[A] = OrMore(noBagQuotLabel, false, value)
   def orMore[B](value: B)(using Encoder[B], A =:= Option[B]): OrMore[B] = OrMore(noBagQuotLabel, false, value)
 
   /**
@@ -164,7 +164,7 @@ trait Column[A]:
   @targetName("_orMore")
   def >=[B](value: B)(using Encoder[B], A =:= Option[B]): OrMore[B] = orMore(value)
 
-  def over(value: A)(using Encoder[A]): Over[A] = Over(noBagQuotLabel, false, value)
+  def over(value:    A)(using Encoder[A]):                  Over[A] = Over(noBagQuotLabel, false, value)
   def over[B](value: B)(using Encoder[B], A =:= Option[B]): Over[B] = Over(noBagQuotLabel, false, value)
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -17,7 +17,6 @@ import ldbc.sql.ResultSet
 import ldbc.dsl.*
 import ldbc.dsl.codec.*
 
-import ldbc.statement.interpreter.Extract
 import ldbc.statement.Expression.*
 
 /**
@@ -120,8 +119,11 @@ trait Column[A]:
         )
       override private[ldbc] def list: List[Column[?]] = self.list ++ fb.list
 
-  def _equals(value: Extract[A])(using Encoder[Extract[A]]): MatchCondition[A] =
-    MatchCondition[A](noBagQuotLabel, false, value)
+  def _equals[B](value: B)(using Encoder[B], A =:= Option[B]): MatchCondition[B] =
+    MatchCondition(noBagQuotLabel, false, value)
+
+  def _equals(value: A)(using Encoder[A]): MatchCondition[A] =
+    MatchCondition(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values match in a SELECT statement.
@@ -137,10 +139,12 @@ trait Column[A]:
    *   A query to check whether the values match in a Where statement
    */
   @targetName("matchCondition")
-  def ===(value: Extract[A])(using Encoder[Extract[A]]): MatchCondition[A] = _equals(value)
+  def ===(value: A)(using Encoder[A]): MatchCondition[A] = _equals(value)
+  @targetName("matchCondition")
+  def ===[B](value: B)(using Encoder[B], A =:= Option[B]): MatchCondition[B] = _equals(value)
 
-  def orMore(value: Extract[A])(using Encoder[Extract[A]]): OrMore[A] =
-    OrMore[A](noBagQuotLabel, false, value)
+  def orMore(value: A)(using Encoder[A]): OrMore[A] = OrMore(noBagQuotLabel, false, value)
+  def orMore[B](value: B)(using Encoder[B], A =:= Option[B]): OrMore[B] = OrMore(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are greater than or equal to in a SELECT statement.
@@ -156,10 +160,12 @@ trait Column[A]:
    *   A query to check whether the values are greater than or equal to in a Where statement
    */
   @targetName("_orMore")
-  def >=(value: Extract[A])(using Encoder[Extract[A]]): OrMore[A] = orMore(value)
+  def >=(value: A)(using Encoder[A]): OrMore[A] = orMore(value)
+  @targetName("_orMore")
+  def >=[B](value: B)(using Encoder[B], A =:= Option[B]): OrMore[B] = orMore(value)
 
-  def over(value: Extract[A])(using Encoder[Extract[A]]): Over[A] =
-    Over[A](noBagQuotLabel, false, value)
+  def over(value: A)(using Encoder[A]): Over[A] = Over(noBagQuotLabel, false, value)
+  def over[B](value: B)(using Encoder[B], A =:= Option[B]): Over[B] = Over(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are greater than in a SELECT statement.
@@ -175,10 +181,14 @@ trait Column[A]:
    *   A query to check whether the values are greater than in a Where statement
    */
   @targetName("_over")
-  def >(value: Extract[A])(using Encoder[Extract[A]]): Over[A] = over(value)
+  def >(value: A)(using Encoder[A]): Over[A] = over(value)
+  @targetName("_over")
+  def >[B](value: B)(using Encoder[B], A =:= Option[B]): Over[B] = over(value)
 
-  def lessThanOrEqual(value: Extract[A])(using Encoder[Extract[A]]): LessThanOrEqualTo[A] =
-    LessThanOrEqualTo[A](noBagQuotLabel, false, value)
+  def lessThanOrEqual(value: A)(using Encoder[A]): LessThanOrEqualTo[A] =
+    LessThanOrEqualTo(noBagQuotLabel, false, value)
+  def lessThanOrEqual[B](value: B)(using Encoder[B], A =:= Option[B]): LessThanOrEqualTo[B] =
+    LessThanOrEqualTo(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are less than or equal to in a SELECT statement.
@@ -194,10 +204,14 @@ trait Column[A]:
    *   A query to check whether the values are less than or equal to in a Where statement
    */
   @targetName("_lessThanOrEqual")
-  def <=(value: Extract[A])(using Encoder[Extract[A]]): LessThanOrEqualTo[A] = lessThanOrEqual(value)
+  def <=(value: A)(using Encoder[A]): LessThanOrEqualTo[A] = lessThanOrEqual(value)
+  @targetName("_lessThanOrEqual")
+  def <=[B](value: B)(using Encoder[B], A =:= Option[B]): LessThanOrEqualTo[B] = lessThanOrEqual(value)
 
-  def lessThan(value: Extract[A])(using Encoder[Extract[A]]): LessThan[A] =
-    LessThan[A](noBagQuotLabel, false, value)
+  def lessThan(value: A)(using Encoder[A]): LessThan[A] =
+    LessThan(noBagQuotLabel, false, value)
+  def lessThan[B](value: B)(using Encoder[B], A =:= Option[B]): LessThan[B] =
+    LessThan(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are less than in a SELECT statement.
@@ -213,10 +227,14 @@ trait Column[A]:
    *   A query to check whether the values are less than in a Where statement
    */
   @targetName("_lessThan")
-  def <(value: Extract[A])(using Encoder[Extract[A]]): LessThan[A] = lessThan(value)
+  def <(value: A)(using Encoder[A]): LessThan[A] = lessThan(value)
+  @targetName("_lessThan")
+  def <[B](value: B)(using Encoder[B], A =:= Option[B]): LessThan[B] = lessThan(value)
 
-  def notEqual(value: Extract[A])(using Encoder[Extract[A]]): NotEqual[A] =
-    NotEqual[A]("<>", noBagQuotLabel, false, value)
+  def notEqual(value: A)(using Encoder[A]): NotEqual[A] =
+    NotEqual("<>", noBagQuotLabel, false, value)
+  def notEqual[B](value: B)(using Encoder[B], A =:= Option[B]): NotEqual[B] =
+    NotEqual("<>", noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are not equal in a SELECT statement.
@@ -232,7 +250,9 @@ trait Column[A]:
    *   A query to check whether the values are not equal in a Where statement
    */
   @targetName("_notEqual")
-  def <>(value: Extract[A])(using Encoder[Extract[A]]): NotEqual[A] = notEqual(value)
+  def <>(value: A)(using Encoder[A]): NotEqual[A] = notEqual(value)
+  @targetName("_notEqual")
+  def <>[B](value: B)(using Encoder[B], A =:= Option[B]): NotEqual[B] = notEqual(value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are not equal in a SELECT statement.
@@ -248,8 +268,11 @@ trait Column[A]:
    *   A query to check whether the values are not equal in a Where statement
    */
   @targetName("_!equal")
-  def !==(value: Extract[A])(using Encoder[Extract[A]]): NotEqual[A] =
-    NotEqual[A]("!=", noBagQuotLabel, false, value)
+  def !==(value: A)(using Encoder[A]): NotEqual[A] =
+    NotEqual("!=", noBagQuotLabel, false, value)
+  @targetName("_!equal")
+  def !==[B](value: B)(using Encoder[B], A =:= Option[B]): NotEqual[B] =
+    NotEqual("!=", noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are equal in a SELECT statement.
@@ -269,8 +292,10 @@ trait Column[A]:
   def IS[B <: "TRUE" | "FALSE" | "UNKNOWN" | "NULL"](value: B): Is[B] =
     Is[B](noBagQuotLabel, false, value)
 
-  def nullSafeEqual(value: Extract[A])(using Encoder[Extract[A]]): NullSafeEqual[A] =
-    NullSafeEqual[A](noBagQuotLabel, false, value)
+  def nullSafeEqual(value: A)(using Encoder[A]): NullSafeEqual[A] =
+    NullSafeEqual(noBagQuotLabel, false, value)
+  def nullSafeEqual[B](value: B)(using Encoder[B], A =:= Option[B]): NullSafeEqual[B] =
+    NullSafeEqual(noBagQuotLabel, false, value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are equal in a SELECT statement.
@@ -286,7 +311,9 @@ trait Column[A]:
    *   A query to check whether the values are equal in a Where statement
    */
   @targetName("_nullSafeEqual")
-  def <=>(value: Extract[A])(using Encoder[Extract[A]]): NullSafeEqual[A] = nullSafeEqual(value)
+  def <=>(value: A)(using Encoder[A]): NullSafeEqual[A] = nullSafeEqual(value)
+  @targetName("_nullSafeEqual")
+  def <=>[B](value: B)(using Encoder[B], A =:= Option[B]): NullSafeEqual[B] = nullSafeEqual(value)
 
   /**
    * A function that sets a WHERE condition to check whether the values are equal in a SELECT statement.
@@ -301,8 +328,10 @@ trait Column[A]:
    * @return
    *   A query to check whether the values are equal in a Where statement
    */
-  def IN(value: Extract[A]*)(using Encoder[Extract[A]]): In[A] =
-    In[A](noBagQuotLabel, false, value*)
+  def IN(value: A*)(using Encoder[A]): In[A] =
+    In(noBagQuotLabel, false, value*)
+  def IN[B](value: B*)(using Encoder[B], A =:= Option[B]): In[B] =
+    In(noBagQuotLabel, false, value*)
 
   /**
    * A function that sets a WHERE condition to check whether a value is included in a specified range in a SELECT statement.
@@ -319,8 +348,10 @@ trait Column[A]:
    * @return
    *   A query to check whether the value is included in a specified range in a Where statement
    */
-  def BETWEEN(start: Extract[A], end: Extract[A])(using Encoder[Extract[A]]): Between[A] =
-    Between[A](noBagQuotLabel, false, start, end)
+  def BETWEEN(start: A, end: A)(using Encoder[A]): Between[A] =
+    Between(noBagQuotLabel, false, start, end)
+  def BETWEEN[B](start: B, end: B)(using Encoder[B], A =:= Option[B]): Between[B] =
+    Between(noBagQuotLabel, false, start, end)
 
   /**
    * A function to set a WHERE condition to check a value with an ambiguous search in a SELECT statement.
@@ -335,8 +366,10 @@ trait Column[A]:
    * @return
    *   A query to check a value with an ambiguous search in a Where statement
    */
-  def LIKE(value: Extract[A])(using Encoder[Extract[A]]): Like[A] =
-    Like[A](noBagQuotLabel, false, value)
+  def LIKE(value: A)(using Encoder[A]): Like[A] =
+    Like(noBagQuotLabel, false, value)
+  def LIKE[B](value: B)(using Encoder[B], A =:= Option[B]): Like[B] =
+    Like(noBagQuotLabel, false, value)
 
   /**
    * A function to set a WHERE condition to check a value with an ambiguous search in a SELECT statement.
@@ -353,8 +386,10 @@ trait Column[A]:
    * @return
    *   A query to check a value with an ambiguous search in a Where statement
    */
-  def LIKE_ESCAPE(like: Extract[A], escape: Extract[A])(using Encoder[Extract[A]]): LikeEscape[A] =
-    LikeEscape[A](noBagQuotLabel, false, like, escape)
+  def LIKE_ESCAPE(like: A, escape: A)(using Encoder[A]): LikeEscape[A] =
+    LikeEscape(noBagQuotLabel, false, like, escape)
+  def LIKE_ESCAPE[B](like: B, escape: B)(using Encoder[B], A =:= Option[B]): LikeEscape[B] =
+    LikeEscape(noBagQuotLabel, false, like, escape)
 
   /**
    * A function to set a WHERE condition to check values in a regular expression in a SELECT statement.
@@ -369,11 +404,15 @@ trait Column[A]:
    * @return
    *   A query to check values in a regular expression in a Where statement
    */
-  def REGEXP(value: Extract[A])(using Encoder[Extract[A]]): Regexp[A] =
-    Regexp[A](noBagQuotLabel, false, value)
+  def REGEXP(value: A)(using Encoder[A]): Regexp[A] =
+    Regexp(noBagQuotLabel, false, value)
+  def REGEXP[B](value: B)(using Encoder[B], A =:= Option[B]): Regexp[B] =
+    Regexp(noBagQuotLabel, false, value)
 
-  def leftShift(value: Extract[A])(using Encoder[Extract[A]]): LeftShift[A] =
-    LeftShift[A](noBagQuotLabel, false, value)
+  def leftShift(value: A)(using Encoder[A]): LeftShift[A] =
+    LeftShift(noBagQuotLabel, false, value)
+  def leftShift[B](value: B)(using Encoder[B], A =:= Option[B]): LeftShift[B] =
+    LeftShift(noBagQuotLabel, false, value)
 
   /**
    * A function to set a WHERE condition to check whether the values are shifted to the left in a SELECT statement.
@@ -389,10 +428,14 @@ trait Column[A]:
    *   A query to check whether the values are shifted to the left in a Where statement
    */
   @targetName("_leftShift")
-  def <<(value: Extract[A])(using Encoder[Extract[A]]): LeftShift[A] = leftShift(value)
+  def <<(value: A)(using Encoder[A]): LeftShift[A] = leftShift(value)
+  @targetName("_leftShift")
+  def <<[B](value: B)(using Encoder[B], A =:= Option[B]): LeftShift[B] = leftShift(value)
 
-  def rightShift(value: Extract[A])(using Encoder[Extract[A]]): RightShift[A] =
+  def rightShift(value: A)(using Encoder[A]): RightShift[A] =
     RightShift[A](noBagQuotLabel, false, value)
+  def rightShift[B](value: B)(using Encoder[B], A =:= Option[B]): RightShift[B] =
+    RightShift(noBagQuotLabel, false, value)
 
   /**
    * A function to set a WHERE condition to check whether the values are shifted to the right in a SELECT statement.
@@ -408,7 +451,9 @@ trait Column[A]:
    *   A query to check whether the values are shifted to the right in a Where statement
    */
   @targetName("_rightShift")
-  def >>(value: Extract[A])(using Encoder[Extract[A]]): RightShift[A] = rightShift(value)
+  def >>(value: A)(using Encoder[A]): RightShift[A] = rightShift(value)
+  @targetName("_rightShift")
+  def >>[B](value: B)(using Encoder[B], A =:= Option[B]): RightShift[B] = rightShift(value)
 
   /**
    * A function to set a WHERE condition to check whether the values are added in a SELECT statement.
@@ -425,8 +470,10 @@ trait Column[A]:
    * @return
    *   A query to check whether the values are added in a Where statement
    */
-  def DIV(cond: Extract[A], result: Extract[A])(using Encoder[Extract[A]]): Div[A] =
-    Div[A](noBagQuotLabel, false, cond, result)
+  def DIV(cond: A, result: A)(using Encoder[A]): Div[A] =
+    Div(noBagQuotLabel, false, cond, result)
+  def DIV[B](cond: B, result: B)(using Encoder[B], A =:= Option[B]): Div[B] =
+    Div(noBagQuotLabel, false, cond, result)
 
   /**
    * A function to set the WHERE condition for modulo operations in a SELECT statement.
@@ -443,11 +490,15 @@ trait Column[A]:
    * @return
    *   A query to check the modulo operation in a Where statement
    */
-  def MOD(cond: Extract[A], result: Extract[A])(using Encoder[Extract[A]]): Mod[A] =
-    Mod[A]("MOD", noBagQuotLabel, false, cond, result)
+  def MOD(cond: A, result: A)(using Encoder[A]): Mod[A] =
+    Mod("MOD", noBagQuotLabel, false, cond, result)
+  def MOD[B](cond: B, result: B)(using Encoder[B], A =:= Option[B]): Mod[B] =
+    Mod("MOD", noBagQuotLabel, false, cond, result)
 
-  def mod(cond: Extract[A], result: Extract[A])(using Encoder[Extract[A]]): Mod[A] =
-    Mod[A]("%", noBagQuotLabel, false, cond, result)
+  def mod(cond: A, result: A)(using Encoder[A]): Mod[A] =
+    Mod("%", noBagQuotLabel, false, cond, result)
+  def mod[B](cond: B, result: B)(using Encoder[B], A =:= Option[B]): Mod[B] =
+    Mod("%", noBagQuotLabel, false, cond, result)
 
   /**
    * A function to set the WHERE condition for modulo operations in a SELECT statement.
@@ -465,10 +516,14 @@ trait Column[A]:
    *   A query to check the modulo operation in a Where statement
    */
   @targetName("_mod")
-  def %(cond: Extract[A], result: Extract[A])(using Encoder[Extract[A]]): Mod[A] = mod(cond, result)
+  def %(cond: A, result: A)(using Encoder[A]): Mod[A] = mod(cond, result)
+  @targetName("_mod")
+  def %[B](cond: B, result: B)(using Encoder[B], A =:= Option[B]): Mod[B] = mod(cond, result)
 
-  def bitXOR(value: Extract[A])(using Encoder[Extract[A]]): BitXOR[A] =
-    BitXOR[A](noBagQuotLabel, false, value)
+  def bitXOR(value: A)(using Encoder[A]): BitXOR[A] =
+    BitXOR(noBagQuotLabel, false, value)
+  def bitXOR[B](value: B)(using Encoder[B], A =:= Option[B]): BitXOR[B] =
+    BitXOR(noBagQuotLabel, false, value)
 
   /**
    * A function to set the WHERE condition for bitwise XOR operations in a SELECT statement.
@@ -484,10 +539,14 @@ trait Column[A]:
    *   A query to check the bitwise XOR operation in a Where statement
    */
   @targetName("_bitXOR")
-  def ^(value: Extract[A])(using Encoder[Extract[A]]): BitXOR[A] = bitXOR(value)
+  def ^(value: A)(using Encoder[A]): BitXOR[A] = bitXOR(value)
+  @targetName("_bitXOR")
+  def ^[B](value: B)(using Encoder[B], A =:= Option[B]): BitXOR[B] = bitXOR(value)
 
-  def bitFlip(value: Extract[A])(using Encoder[Extract[A]]): BitFlip[A] =
-    BitFlip[A](noBagQuotLabel, false, value)
+  def bitFlip(value: A)(using Encoder[A]): BitFlip[A] =
+    BitFlip(noBagQuotLabel, false, value)
+  def bitFlip[B](value: B)(using Encoder[B], A =:= Option[B]): BitFlip[B] =
+    BitFlip(noBagQuotLabel, false, value)
 
   /**
    * A function to set the WHERE condition for bitwise NOT operations in a SELECT statement.
@@ -503,7 +562,9 @@ trait Column[A]:
    *   A query to check the bitwise NOT operation in a Where statement
    */
   @targetName("_bitFlip")
-  def ~(value: Extract[A])(using Encoder[Extract[A]]): BitFlip[A] = bitFlip(value)
+  def ~(value: A)(using Encoder[A]): BitFlip[A] = bitFlip(value)
+  @targetName("_bitFlip")
+  def ~[B](value: B)(using Encoder[B], A =:= Option[B]): BitFlip[B] = bitFlip(value)
 
   def combine(other: Column[A])(using Codec[A]): Column.MultiColumn[A] =
     Column.MultiColumn[A]("+", this, other)

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Expression.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Expression.scala
@@ -9,8 +9,6 @@ package ldbc.statement
 import ldbc.dsl.*
 import ldbc.dsl.codec.Encoder
 
-import ldbc.statement.interpreter.Extract
-
 /**
  * Trait for the syntax of expressions available in MySQL.
  *
@@ -77,14 +75,14 @@ object Expression:
     /**
      * Value to be set for Statement.
      */
-    def value: Extract[T]
+    def value: T
 
   private[ldbc] trait MultiValue[T] extends Expression:
 
     /**
      * List of values to be set for the Statement.
      */
-    def values: Seq[Extract[T]]
+    def values: Seq[T]
 
   /**
    * A model for joining expressions together.
@@ -158,8 +156,8 @@ object Expression:
     override def parameter: List[Parameter.Dynamic] = List.empty
 
   /** comparison operator */
-  private[ldbc] case class MatchCondition[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class MatchCondition[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag:      String                  = "="
     override def parameter: List[Parameter.Dynamic] = Parameter.Dynamic.many(encoder.encode(value))
@@ -169,8 +167,8 @@ object Expression:
 
     def NOT: MatchCondition[T] = MatchCondition[T](this.column, true, this.value)
 
-  private[ldbc] case class OrMore[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class OrMore[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = ">="
 
@@ -182,8 +180,8 @@ object Expression:
 
     def NOT: OrMore[T] = OrMore[T](this.column, true, this.value)
 
-  private[ldbc] case class Over[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Over[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = ">"
 
@@ -195,8 +193,8 @@ object Expression:
 
     def NOT: Over[T] = Over[T](this.column, true, this.value)
 
-  private[ldbc] case class LessThanOrEqualTo[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class LessThanOrEqualTo[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "<="
 
@@ -208,8 +206,8 @@ object Expression:
 
     def NOT: LessThanOrEqualTo[T] = LessThanOrEqualTo[T](this.column, true, this.value)
 
-  private[ldbc] case class LessThan[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class LessThan[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "<"
 
@@ -221,8 +219,8 @@ object Expression:
 
     def NOT: LessThan[T] = LessThan[T](this.column, true, this.value)
 
-  private[ldbc] case class NotEqual[T](flag: String, column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class NotEqual[T](flag: String, column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def parameter: List[Parameter.Dynamic] = Parameter.Dynamic.many(encoder.encode(value))
 
@@ -247,8 +245,8 @@ object Expression:
 
     def NOT: Is[T] = Is[T](this.column, true, this.value)
 
-  private[ldbc] case class NullSafeEqual[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class NullSafeEqual[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "<=>"
 
@@ -260,8 +258,8 @@ object Expression:
 
     def NOT: NullSafeEqual[T] = NullSafeEqual[T](this.column, true, this.value)
 
-  private[ldbc] case class In[T](column: String, isNot: Boolean, values: Extract[T]*)(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class In[T](column: String, isNot: Boolean, values: T*)(using
+    encoder: Encoder[T]
   ) extends MultiValue[T]:
     override def flag: String = "IN"
 
@@ -274,8 +272,8 @@ object Expression:
 
     def NOT: In[T] = In[T](this.column, true, this.values*)
 
-  private[ldbc] case class Between[T](column: String, isNot: Boolean, values: Extract[T]*)(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Between[T](column: String, isNot: Boolean, values: T*)(using
+    encoder: Encoder[T]
   ) extends MultiValue[T]:
     override def flag: String = "BETWEEN"
 
@@ -288,8 +286,8 @@ object Expression:
 
     def NOT: Between[T] = Between[T](this.column, true, this.values*)
 
-  private[ldbc] case class Like[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Like[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "LIKE"
 
@@ -301,8 +299,8 @@ object Expression:
 
     def NOT: Like[T] = Like[T](this.column, true, this.value)
 
-  private[ldbc] case class LikeEscape[T](column: String, isNot: Boolean, values: Extract[T]*)(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class LikeEscape[T](column: String, isNot: Boolean, values: T*)(using
+    encoder: Encoder[T]
   ) extends MultiValue[T]:
     override def flag: String = "LIKE"
 
@@ -315,8 +313,8 @@ object Expression:
 
     def NOT: LikeEscape[T] = LikeEscape[T](this.column, true, this.values*)
 
-  private[ldbc] case class Regexp[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Regexp[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "REGEXP"
 
@@ -328,8 +326,8 @@ object Expression:
 
     def NOT: Regexp[T] = Regexp[T](this.column, true, this.value)
 
-  private[ldbc] case class LeftShift[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class LeftShift[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "<<"
 
@@ -341,8 +339,8 @@ object Expression:
 
     def NOT: LeftShift[T] = LeftShift[T](this.column, true, this.value)
 
-  private[ldbc] case class RightShift[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class RightShift[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = ">>"
 
@@ -354,8 +352,8 @@ object Expression:
 
     def NOT: RightShift[T] = RightShift[T](this.column, true, this.value)
 
-  private[ldbc] case class Div[T](column: String, isNot: Boolean, values: Extract[T]*)(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Div[T](column: String, isNot: Boolean, values: T*)(using
+    encoder: Encoder[T]
   ) extends MultiValue[T]:
     override def flag: String = "DIV"
 
@@ -368,8 +366,8 @@ object Expression:
 
     def NOT: Div[T] = Div[T](this.column, true, this.values*)
 
-  private[ldbc] case class Mod[T](flag: String, column: String, isNot: Boolean, values: Extract[T]*)(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class Mod[T](flag: String, column: String, isNot: Boolean, values: T*)(using
+    encoder: Encoder[T]
   ) extends MultiValue[T]:
     override def parameter: List[Parameter.Dynamic] =
       values.flatMap(value => Parameter.Dynamic.many(encoder.encode(value))).toList
@@ -380,8 +378,8 @@ object Expression:
 
     def NOT: Mod[T] = Mod[T](this.flag, this.column, true, this.values*)
 
-  private[ldbc] case class BitXOR[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class BitXOR[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "^"
 
@@ -393,8 +391,8 @@ object Expression:
 
     def NOT: BitXOR[T] = BitXOR[T](this.column, true, this.value)
 
-  private[ldbc] case class BitFlip[T](column: String, isNot: Boolean, value: Extract[T])(using
-    encoder: Encoder[Extract[T]]
+  private[ldbc] case class BitFlip[T](column: String, isNot: Boolean, value: T)(using
+    encoder: Encoder[T]
   ) extends SingleValue[T]:
     override def flag: String = "~"
 

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
@@ -12,17 +12,17 @@ import ldbc.dsl.codec.Codec
 
 opaque type Token = String
 object Token:
-  def fromString(value: String): Token = value
-  extension (token: Token) def value: String = token
+  def fromString(value: String):          Token  = value
+  extension (token:     Token) def value: String = token
 
 class ColumnTest extends AnyFlatSpec:
 
   given Codec[Token] = Codec[String].imap(Token.fromString)(_.value)
 
-  private val id1   = Column.Impl[Long]("id")
-  private val id2   = Column.Impl[Option[Long]]("id")
-  private val name1 = Column.Impl[String]("name")
-  private val name2 = Column.Impl[Option[String]]("name")
+  private val id1    = Column.Impl[Long]("id")
+  private val id2    = Column.Impl[Option[Long]]("id")
+  private val name1  = Column.Impl[String]("name")
+  private val name2  = Column.Impl[Option[String]]("name")
   private val token1 = Column.Impl[Token]("token")
   private val token2 = Column.Impl[Option[Token]]("token")
 

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
@@ -8,12 +8,23 @@ package ldbc.statement
 
 import org.scalatest.flatspec.AnyFlatSpec
 
+import ldbc.dsl.codec.Codec
+
+opaque type Token = String
+object Token:
+  def fromString(value: String): Token = value
+  extension (token: Token) def value: String = token
+
 class ColumnTest extends AnyFlatSpec:
+
+  given Codec[Token] = Codec[String].imap(Token.fromString)(_.value)
 
   private val id1   = Column.Impl[Long]("id")
   private val id2   = Column.Impl[Option[Long]]("id")
   private val name1 = Column.Impl[String]("name")
   private val name2 = Column.Impl[Option[String]]("name")
+  private val token1 = Column.Impl[Token]("token")
+  private val token2 = Column.Impl[Option[Token]]("token")
 
   it should "The string of the expression syntax that constructs the match with the specified value matches the specified string." in {
     assert((id1 === 1L).statement === "id = ?")
@@ -109,32 +120,32 @@ class ColumnTest extends AnyFlatSpec:
   }
 
   it should "The string constructed by the expression syntax that performs the integer division operation to determine if it matches matches the specified string." in {
-    assert((id1 DIV (5, 10)).statement === "id DIV ? = ?")
-    assert((id1 DIV (5, 10)).NOT.statement === "NOT id DIV ? = ?")
-    assert((id2 DIV (5, 10)).statement === "id DIV ? = ?")
-    assert((id2 DIV (5, 10)).NOT.statement === "NOT id DIV ? = ?")
+    assert((id1 DIV (5L, 10L)).statement === "id DIV ? = ?")
+    assert((id1 DIV (5L, 10L)).NOT.statement === "NOT id DIV ? = ?")
+    assert((id2 DIV (5L, 10L)).statement === "id DIV ? = ?")
+    assert((id2 DIV (5L, 10L)).NOT.statement === "NOT id DIV ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the operation to find the remainder and determines whether it matches matches the specified string." in {
-    assert((id1 MOD (5, 0)).statement === "id MOD ? = ?")
-    assert((id1 MOD (5, 0)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id1 % (5, 0)).statement === "id % ? = ?")
-    assert((id1 % (5, 0)).NOT.statement === "NOT id % ? = ?")
-    assert((id2 MOD (5, 0)).statement === "id MOD ? = ?")
-    assert((id2 MOD (5, 0)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id2 % (5, 0)).statement === "id % ? = ?")
-    assert((id2 % (5, 0)).NOT.statement === "NOT id % ? = ?")
+    assert((id1 MOD (5L, 0L)).statement === "id MOD ? = ?")
+    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
+    assert((id1 % (5L, 0L)).statement === "id % ? = ?")
+    assert((id1 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
+    assert((id2 MOD (5L, 0L)).statement === "id MOD ? = ?")
+    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
+    assert((id2 % (5L, 0L)).statement === "id % ? = ?")
+    assert((id2 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the bit XOR operation to determine if it matches matches the specified string." in {
-    assert((id1 MOD (5, 0)).statement === "id MOD ? = ?")
-    assert((id1 MOD (5, 0)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id1 % (5, 0)).statement === "id % ? = ?")
-    assert((id1 % (5, 0)).NOT.statement === "NOT id % ? = ?")
-    assert((id2 MOD (5, 0)).statement === "id MOD ? = ?")
-    assert((id2 MOD (5, 0)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id2 % (5, 0)).statement === "id % ? = ?")
-    assert((id2 % (5, 0)).NOT.statement === "NOT id % ? = ?")
+    assert((id1 MOD (5L, 0L)).statement === "id MOD ? = ?")
+    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
+    assert((id1 % (5L, 0L)).statement === "id % ? = ?")
+    assert((id1 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
+    assert((id2 MOD (5L, 0L)).statement === "id MOD ? = ?")
+    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
+    assert((id2 % (5L, 0L)).statement === "id % ? = ?")
+    assert((id2 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the left shift operation to determine if it matches matches the specified string." in {
@@ -189,4 +200,18 @@ class ColumnTest extends AnyFlatSpec:
   it should "The query string of the combined expression matches the specified string." in {
     val age = Column.Impl[Option[Int]]("age")
     assert((id1 === 1L && name1 === "name" || age > 25).statement === "(id = ? AND name = ? OR age > ?)")
+  }
+
+  it should "Comparison operators can also be used when using Opaque Type Alias." in {
+    assert((token1 === Token.fromString("token")).statement === "token = ?")
+    assert((token1 === Token.fromString("token")).NOT.statement === "NOT token = ?")
+    assert((token1 === Token.fromString("token")).statement === "token = ?")
+    assert((token1 === Token.fromString("token")).NOT.statement === "NOT token = ?")
+  }
+
+  it should "Comparison operators can also be used when using Opaque Type Alias of Option type." in {
+    assert((token2 === Token.fromString("token")).statement === "token = ?")
+    assert((token2 === Token.fromString("token")).NOT.statement === "NOT token = ?")
+    assert((token2 === Token.fromString("token")).statement === "token = ?")
+    assert((token2 === Token.fromString("token")).NOT.statement === "NOT token = ?")
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Fixed a compile error in comparison operators due to the use of opaque type aliases.

## Fixes

Resolved: https://github.com/takapi327/ldbc/issues/356

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
