### PR TITLE
Empty VALUES in INSERT statement causes error statement to be issued

### DIFF
--- a/benchmark/src/main/scala/benchmark/wrapper/ldbc/Insert.scala
+++ b/benchmark/src/main/scala/benchmark/wrapper/ldbc/Insert.scala
@@ -69,7 +69,7 @@ class Insert:
       .use { conn =>
         query
           .insertInto(test => test.c1 *: test.c2)
-          .values(records.toList*)
+          .values(records)
           .update
           .commit(conn)
       }

--- a/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
+++ b/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
@@ -8,6 +8,8 @@ package ldbc.query.builder
 
 import org.scalatest.flatspec.AnyFlatSpec
 
+import cats.data.NonEmptyList
+
 import ldbc.query.builder.syntax.io.*
 
 class TableQueryTest extends AnyFlatSpec:
@@ -230,10 +232,9 @@ class TableQueryTest extends AnyFlatSpec:
     assert(
       query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
     )
-    val values: List[(Long, String, Option[String])] = List((1L, "p2", Some("p3")), (2L, "p2", None))
     assert(
       query
-        .insert(values*)
+        .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
     )
     assert(
@@ -257,7 +258,7 @@ class TableQueryTest extends AnyFlatSpec:
     assert(
       (query
         .++=(
-          List(
+          NonEmptyList.of(
             Test(1L, "p2", Some("p3")),
             Test(2L, "p2", None)
           )
@@ -272,7 +273,7 @@ class TableQueryTest extends AnyFlatSpec:
     )
     assert(
       query
-        .insert(values*)
+        .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
     )
@@ -293,14 +294,14 @@ class TableQueryTest extends AnyFlatSpec:
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
     )
     assert(
-      (query ++= List(
+      (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(_.p1)
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
     )
     assert(
-      (query ++= List(
+      (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)

--- a/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
+++ b/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
@@ -6,9 +6,9 @@
 
 package ldbc.query.builder
 
-import org.scalatest.flatspec.AnyFlatSpec
-
 import cats.data.NonEmptyList
+
+import org.scalatest.flatspec.AnyFlatSpec
 
 import ldbc.query.builder.syntax.io.*
 

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
@@ -8,6 +8,8 @@ package ldbc.schema
 
 import org.scalatest.flatspec.AnyFlatSpec
 
+import cats.data.NonEmptyList
+
 case class Test(p1: Long, p2: String, p3: Option[String])
 case class JoinTest(p1: Long, p2: String, p3: Option[String])
 case class JoinTest2(p1: Long, p2: String, p3: Option[String])
@@ -249,10 +251,9 @@ class TableQueryTest extends AnyFlatSpec:
     assert(
       query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
     )
-    val values: List[(Long, String, Option[String])] = List((1L, "p2", Some("p3")), (2L, "p2", None))
     assert(
       query
-        .insert(values*)
+        .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
     )
     assert(
@@ -276,7 +277,7 @@ class TableQueryTest extends AnyFlatSpec:
     assert(
       (query
         .++=(
-          List(
+          NonEmptyList.of(
             Test(1L, "p2", Some("p3")),
             Test(2L, "p2", None)
           )
@@ -291,7 +292,7 @@ class TableQueryTest extends AnyFlatSpec:
     )
     assert(
       query
-        .insert(values*)
+        .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
     )
@@ -312,14 +313,14 @@ class TableQueryTest extends AnyFlatSpec:
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
     )
     assert(
-      (query ++= List(
+      (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(_.p1)
         .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
     )
     assert(
-      (query ++= List(
+      (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
@@ -6,9 +6,9 @@
 
 package ldbc.schema
 
-import org.scalatest.flatspec.AnyFlatSpec
-
 import cats.data.NonEmptyList
+
+import org.scalatest.flatspec.AnyFlatSpec
 
 case class Test(p1: Long, p2: String, p3: Option[String])
 case class JoinTest(p1: Long, p2: String, p3: Option[String])

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
@@ -91,7 +91,7 @@ object Insert:
      * {{{
      *   TableQuery[City]
      *     .insertInto(city => city.id *: city.name)
-     *     .values((1L, "Tokyo"))
+     *     .values(NonEmptyList.one(1L, "Tokyo"))
      * }}}
      *
      * @param values

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Insert.scala
@@ -8,6 +8,8 @@ package ldbc.statement
 
 import scala.annotation.targetName
 
+import cats.data.NonEmptyList
+
 import ldbc.dsl.{ Parameter, SQL }
 
 /**
@@ -76,13 +78,29 @@ object Insert:
      *     .values((1L, "Tokyo"))
      * }}}
      *
+     * @param head
+     *   The values to be inserted.
+     * @param tail
+     *   The values to be inserted.
+     */
+    def values(head: B, tail: B*): Values[A] = values(NonEmptyList(head, tail.toList))
+
+    /**
+     * Method for constructing INSERT ... VALUES statements.
+     *
+     * {{{
+     *   TableQuery[City]
+     *     .insertInto(city => city.id *: city.name)
+     *     .values((1L, "Tokyo"))
+     * }}}
+     *
      * @param values
      *   The values to be inserted.
      */
-    def values(values: B*): Values[A] =
-      val parameterBinders: List[Parameter.Dynamic] = values.flatMap { value =>
+    def values(values: NonEmptyList[B]): Values[A] =
+      val parameterBinders: List[Parameter.Dynamic] = values.toList.flatMap { value =>
         Parameter.Dynamic.many(columns.encoder.encode(value))
-      }.toList
+      }
       Values(
         table,
         s"$statement (${ columns.name }) VALUES ${ List.fill(values.length)(s"(${ List.fill(columns.values)("?").mkString(",") })").mkString(",") }",

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
@@ -109,6 +109,26 @@ trait TableQuery[A, O]:
    *
    * @param mirror
    *   Mirror of Entity
+   * @param head
+   *   Value to be inserted into the table
+   * @param tail
+   *   Value to be inserted into the table
+   */
+  inline def insert(using mirror: Mirror.Of[Entity])(
+    head: mirror.MirroredElemTypes,
+    tail: mirror.MirroredElemTypes*
+  ): Insert[A] = insert(NonEmptyList(head, tail.toList))
+
+  /**
+   * Method to construct a query to insert a table.
+   *
+   * {{{
+   *   TableQuery[City]
+   *     .insert(NonEmptyList.one(1L, "Tokyo"))
+   * }}}
+   *
+   * @param mirror
+   *   Mirror of Entity
    * @param values
    *   Value to be inserted into the table
    */
@@ -154,6 +174,21 @@ trait TableQuery[A, O]:
    *
    * {{{
    *   TableQuery[City] ++= List(City(1L, "Tokyo"), City(2L, "Osaka"))
+   * }}}
+   *
+   * @param head
+   *   Value to be inserted into the table
+   * @param tail
+   *   Value to be inserted into the table
+   */
+  @targetName("insertProducts")
+  inline def ++=(head: Entity, tail: Entity*): Insert[A] = ++=(NonEmptyList(head, tail.toList))
+
+  /**
+   * Method to construct a query to insert a table.
+   *
+   * {{{
+   *   TableQuery[City] ++= NonEmptyList(City(1L, "Tokyo"), City(2L, "Osaka"))
    * }}}
    *
    * @param values

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/TableQuery.scala
@@ -120,7 +120,7 @@ trait TableQuery[A, O]:
   ): Insert[A] =
     inline this match
       case Join.On(_, _, _, _, _) => error("Join Query does not yet support Insert processing.")
-      case _ => insert[mirror.MirroredElemTypes](NonEmptyList(head, tail.toList))
+      case _                      => insert[mirror.MirroredElemTypes](NonEmptyList(head, tail.toList))
 
   /**
    * Method to construct a query to insert a table.

--- a/tests/src/test/scala/ldbc/tests/TableQueryUpdateConnectionTest.scala
+++ b/tests/src/test/scala/ldbc/tests/TableQueryUpdateConnectionTest.scala
@@ -8,6 +8,7 @@ package ldbc.tests
 
 import com.mysql.cj.jdbc.MysqlDataSource
 
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 
 import cats.effect.*
@@ -107,42 +108,40 @@ trait TableQueryUpdateConnectionTest extends CatsEffectSuite:
       connection.use { conn =>
         country
           .insert(
-            List(
-              (
-                code(2),
-                s"${ prefix }_Test2",
-                Country.Continent.Asia,
-                "Northeast",
-                BigDecimal.decimal(390757.00),
-                None,
-                1,
-                None,
-                None,
-                None,
-                "Test",
-                "Test",
-                None,
-                None,
-                code(2)
-              ),
-              (
-                code(3),
-                s"${ prefix }_Test3",
-                Country.Continent.Asia,
-                "Northeast",
-                BigDecimal.decimal(390757.00),
-                None,
-                1,
-                None,
-                None,
-                None,
-                "Test",
-                "Test",
-                None,
-                None,
-                code(3)
-              )
-            )*
+            (
+              code(2),
+              s"${ prefix }_Test2",
+              Country.Continent.Asia,
+              "Northeast",
+              BigDecimal.decimal(390757.00),
+              None,
+              1,
+              None,
+              None,
+              None,
+              "Test",
+              "Test",
+              None,
+              None,
+              code(2)
+            ),
+            (
+              code(3),
+              s"${ prefix }_Test3",
+              Country.Continent.Asia,
+              "Northeast",
+              BigDecimal.decimal(390757.00),
+              None,
+              1,
+              None,
+              None,
+              None,
+              "Test",
+              "Test",
+              None,
+              None,
+              code(3)
+            )
           )
           .update
           .commit(conn)
@@ -219,7 +218,7 @@ trait TableQueryUpdateConnectionTest extends CatsEffectSuite:
     )
     assertIO(
       connection.use { conn =>
-        (country ++= List(newCountry1, newCountry2)).update
+        (country ++= NonEmptyList.of(newCountry1, newCountry2)).update
           .commit(conn)
       },
       2

--- a/tests/src/test/scala/ldbc/tests/TableSchemaUpdateConnectionTest.scala
+++ b/tests/src/test/scala/ldbc/tests/TableSchemaUpdateConnectionTest.scala
@@ -8,6 +8,7 @@ package ldbc.tests
 
 import com.mysql.cj.jdbc.MysqlDataSource
 
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 
 import cats.effect.*
@@ -107,42 +108,40 @@ trait TableSchemaUpdateConnectionTest extends CatsEffectSuite:
       connection.use { conn =>
         country
           .insert(
-            List(
-              (
-                code(2),
-                s"${ prefix }_Test2",
-                Country.Continent.Asia,
-                "Northeast",
-                BigDecimal.decimal(390757.00),
-                None,
-                1,
-                None,
-                None,
-                None,
-                "Test",
-                "Test",
-                None,
-                None,
-                code(2)
-              ),
-              (
-                code(3),
-                s"${ prefix }_Test3",
-                Country.Continent.Asia,
-                "Northeast",
-                BigDecimal.decimal(390757.00),
-                None,
-                1,
-                None,
-                None,
-                None,
-                "Test",
-                "Test",
-                None,
-                None,
-                code(3)
-              )
-            )*
+            (
+              code(2),
+              s"${ prefix }_Test2",
+              Country.Continent.Asia,
+              "Northeast",
+              BigDecimal.decimal(390757.00),
+              None,
+              1,
+              None,
+              None,
+              None,
+              "Test",
+              "Test",
+              None,
+              None,
+              code(2)
+            ),
+            (
+              code(3),
+              s"${ prefix }_Test3",
+              Country.Continent.Asia,
+              "Northeast",
+              BigDecimal.decimal(390757.00),
+              None,
+              1,
+              None,
+              None,
+              None,
+              "Test",
+              "Test",
+              None,
+              None,
+              code(3)
+            )
           )
           .update
           .commit(conn)
@@ -219,7 +218,7 @@ trait TableSchemaUpdateConnectionTest extends CatsEffectSuite:
     )
     assertIO(
       connection.use { conn =>
-        (country ++= List(newCountry1, newCountry2)).update
+        (country ++= NonEmptyList.of(newCountry1, newCountry2)).update
           .commit(conn)
       },
       2


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

When an empty array is passed when inserting a value, an unintended statement is issued, so the NonEmptyList of Cats was used to prevent passing an empty array.

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/359

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
