### PR TITLE
Passing an empty value in the IN clause of a WHERE statement throws an error

### DIFF
--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -8,8 +8,8 @@ package ldbc.statement
 
 import scala.annotation.targetName
 
-import cats.InvariantSemigroupal
 import cats.data.NonEmptyList
+import cats.InvariantSemigroupal
 
 import org.typelevel.twiddles.TwiddleSyntax
 
@@ -349,7 +349,7 @@ trait Column[A]:
    * @return
    * A query to check whether the values are equal in a Where statement
    */
-  def IN(head: A, tail: A)(using Encoder[A]): In[A] = self.IN(NonEmptyList.of(head, tail))
+  def IN(head:    A, tail: A)(using Encoder[A]):                  In[A] = self.IN(NonEmptyList.of(head, tail))
   def IN[B](head: B, tail: B)(using Encoder[B], A =:= Option[B]): In[B] = self.IN(NonEmptyList.of(head, tail))
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -349,8 +349,8 @@ trait Column[A]:
    * @return
    * A query to check whether the values are equal in a Where statement
    */
-  def IN(head:    A, tail: A)(using Encoder[A]):                  In[A] = self.IN(NonEmptyList.of(head, tail))
-  def IN[B](head: B, tail: B)(using Encoder[B], A =:= Option[B]): In[B] = self.IN(NonEmptyList.of(head, tail))
+  def IN(head:    A, tail: A*)(using Encoder[A]):                  In[A] = self.IN(NonEmptyList.of(head, tail*))
+  def IN[B](head: B, tail: B*)(using Encoder[B], A =:= Option[B]): In[B] = self.IN(NonEmptyList.of(head, tail*))
 
   /**
    * A function that sets a WHERE condition to check whether a value is included in a specified range in a SELECT statement.

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -9,6 +9,7 @@ package ldbc.statement
 import scala.annotation.targetName
 
 import cats.InvariantSemigroupal
+import cats.data.NonEmptyList
 
 import org.typelevel.twiddles.TwiddleSyntax
 
@@ -319,19 +320,37 @@ trait Column[A]:
    * A function that sets a WHERE condition to check whether the values are equal in a SELECT statement.
    *
    * {{{
-   *   TableQuery[User].select(user => user.name *: user.age).where(_.id IN (1L, 2L, 3L))
+   *   TableQuery[User].select(user => user.name *: user.age).where(_.id IN NonEmptyList.of(1L, 2L, 3L))
    *   // SELECT name, age FROM user WHERE id IN (?, ?, ?)
    * }}}
    *
-   * @param value
+   * @param values
    *   Value to compare
    * @return
    *   A query to check whether the values are equal in a Where statement
    */
-  def IN(value: A*)(using Encoder[A]): In[A] =
-    In(noBagQuotLabel, false, value*)
-  def IN[B](value: B*)(using Encoder[B], A =:= Option[B]): In[B] =
-    In(noBagQuotLabel, false, value*)
+  def IN(values: NonEmptyList[A])(using Encoder[A]): In[A] =
+    In(noBagQuotLabel, false, values.toList*)
+  def IN[B](values: NonEmptyList[B])(using Encoder[B], A =:= Option[B]): In[B] =
+    In(noBagQuotLabel, false, values.toList*)
+
+  /**
+   * A function that sets a WHERE condition to check whether the values are equal in a SELECT statement.
+   *
+   * {{{
+   *   TableQuery[User].select(user => user.name *: user.age).where(_.id IN (1L, 2L, 3L))
+   *   // SELECT name, age FROM user WHERE id IN (?, ?, ?)
+   * }}}
+   *
+   * @param head
+   *   Value to compare
+   * @param tail
+   *   Value to compare
+   * @return
+   * A query to check whether the values are equal in a Where statement
+   */
+  def IN(head: A, tail: A)(using Encoder[A]): In[A] = self.IN(NonEmptyList.of(head, tail))
+  def IN[B](head: B, tail: B)(using Encoder[B], A =:= Option[B]): In[B] = self.IN(NonEmptyList.of(head, tail))
 
   /**
    * A function that sets a WHERE condition to check whether a value is included in a specified range in a SELECT statement.


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

If an empty value is passed in the IN clause of the WHERE statement, an error is thrown, so use NonEmptyList in Cats to prevent passing empty characters.

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/363

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
