### PR TITLE
Add date functions such as YEAR, MONTH, and DAY to Statement

### DIFF
--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -996,12 +996,12 @@ trait DateTime:
 
   /**
    * Function to return the second part of a date or date-time expression.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(p => SECOND(p.birthDate))
    *   // SELECT SECOND(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The column from which to extract the second.
    */
@@ -1015,12 +1015,12 @@ trait DateTime:
 
   /**
    * Function to return the second part of a date or date-time expression.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(_ => SECOND(LocalDateTime.of(2021, 1, 1, 0, 0)))
    *   // SELECT SECOND('2021-01-01 00:00') FROM date_time
    * }}}
-   * 
+   *
    * @param time
    *   The date or date-time expression from which to extract the second.
    */
@@ -1028,6 +1028,48 @@ trait DateTime:
     time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"SECOND('${ time.toString.replaceAll("T", " ") }')")
+
+  /**
+   * Function to calculate the difference time from a date/time or time type value.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(p => SEC_TO_TIME(p.start, p.end))
+   *   // SELECT SEC_TO_TIME(start, end) FROM date_time
+   * }}}
+   * 
+   * @param time
+   *   The start time.
+   * @param interval
+   *   The end time.
+   */
+  def SUBTIME[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime],
+    B <: LocalTime | Option[LocalTime]
+  ](
+    time: Column[A],
+    interval: Column[B]
+  )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"SUBTIME(${time.name}, ${interval.name})")
+
+  /**
+   * Function to calculate the difference time from a date/time or time type value.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => SUBTIME(LocalDateTime.of(2021, 1, 1, 0, 0), LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT SUBTIME('2021-01-01 00:00', '2021-01-01 00:00') FROM date_time
+   * }}}
+   * 
+   * @param time
+   *   The start time.
+   * @param interval
+   *   The end time.
+   */
+  def SUBTIME(
+    time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    interval: LocalTime
+  )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"SUBTIME('${time.toString.replaceAll("T", " ")}', '${interval.toString}')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -343,7 +343,7 @@ trait DateTime:
    *   TableQuery[DateTime].select(p => DAYNAME(p.birthDate))
    *   // SELECT DAYNAME(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The date or date-time column from which to extract the day of the week.
    */
@@ -365,7 +365,7 @@ trait DateTime:
    *   TableQuery[DateTime].select(_ => DAYNAME(LocalDate.of(2021, 1, 1)))
    *   // SELECT DAYNAME('2021-01-01') FROM date_time
    * }}}
-   * 
+   *
    * @param date
    *   The date or date-time expression from which to extract the day of the week.
    */
@@ -374,12 +374,12 @@ trait DateTime:
 
   /**
    * A function that returns the day of the month for date, in the range 1 to 31, or 0 for dates such as '0000-00-00' or '2008-00-00' that have a zero day part.
-   * 
+   *
    * {{{
    *  TableQuery[DateTime].select(p => DAYOFMONTH(p.birthDate))
    *  // SELECT DAYOFMONTH(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The date or date-time column from which to extract the day of the month.
    */
@@ -393,17 +393,52 @@ trait DateTime:
 
   /**
    * A function that returns the day of the month for date, in the range 1 to 31, or 0 for dates such as '0000-00-00' or '2008-00-00' that have a zero day part.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(_ => DAYOFMONTH(LocalDate.of(2021, 1, 1)))
    *   // SELECT DAYOFMONTH('2021-01-01') FROM date_time
    * }}}
-   * 
+   *
    * @param date
    *   The date or date-time expression from which to extract the day of the month.
    */
   def DAYOFMONTH(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"DAYOFMONTH('${ date.toString }')")
+
+  /**
+   * A function that returns the day of the week for date, in the range 1 to 7, where 1 represents Sunday.
+   * Day of the week index (1 = Sunday, 2 = Monday, ..., 7 = Saturday) for date.
+   * 
+   * {{{
+   *  TableQuery[DateTime].select(p => DAYOFWEEK(p.birthDate))
+   *  // SELECT DAYOFWEEK(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The date or date-time column from which to extract the day of the week.
+   */
+  def DAYOFWEEK[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+     column: Column[A]
+   )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFWEEK(${column.name})")
+
+  /**
+   * A function that returns the day of the week for date, in the range 1 to 7, where 1 represents Sunday.
+   * Day of the week index (1 = Sunday, 2 = Monday, ..., 7 = Saturday) for date.
+   * 
+   * {{{
+   *  TableQuery[DateTime].select(_ => DAYOFWEEK(LocalDate.of(2021, 1, 1)))
+   *  // SELECT DAYOFWEEK('2021-01-01') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *   The date or date-time expression from which to extract the day of the week.
+   */
+  def DAYOFWEEK(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFWEEK('${date.toString}')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -654,7 +654,7 @@ trait DateTime:
    *   TableQuery[DateTime].select(_ => LAST_DAY(LocalDate.of(2021, 1, 1)))
    *   // SELECT LAST_DAY('2021-01-01') FROM date_time
    * }}}
-   * 
+   *
    * @param date
    *  The date or date-time expression from which to extract the last day of the month.
    */
@@ -662,6 +662,45 @@ trait DateTime:
     date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
   )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"LAST_DAY('${ date.toString }')")
+
+  /**
+   * Function to return a date calculated from a given year and annual total.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MAKEDATE(p.birthDate, 1))
+   *   // SELECT MAKEDATE(birth_date, 1) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column from which to calculate the date.
+   * @param day
+   *   The annual total from which to calculate the date.
+   *   The annual total must be greater than 0.
+   */
+  def MAKEDATE[A <: Year | Option[Year]](
+    column: Column[A],
+    day: Int
+  )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    require(day > 0, "The annual total must be greater than 0.")
+    Column(s"MAKEDATE(${ column.name }, $day)")
+
+  /**
+   * Function to return a date calculated from a given year and annual total.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MAKEDATE(2021, 1))
+   *   // SELECT MAKEDATE(2021, 1) FROM date_time
+   * }}}
+   *
+   * @param year
+   *   The year from which to calculate the date.
+   * @param day
+   *   The annual total from which to calculate the date.
+   *   The annual total must be greater than 0.
+   */
+  def MAKEDATE(year: Int | Year, day: Int)(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    require(day > 0, "The annual total must be greater than 0.")
+    Column(s"MAKEDATE($year, $day)")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -22,8 +22,8 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[Person].select(p => ADDDATE(p.birthDate, DateTime.Interval.YEAR(1)))
-   *   // SELECT ADDDATE(birth_date, INTERVAL 1 YEAR) FROM person
+   *   TableQuery[DateTime].select(p => ADDDATE(p.birthDate, DateTime.Interval.YEAR(1)))
+   *   // SELECT ADDDATE(birth_date, INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
    * @param column The column to which the addition is to be performed.
@@ -36,8 +36,8 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[Person].select(p => ADDDATE(LocalDate.now, DateTime.Interval.YEAR(1)))
-   *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM person
+   *   TableQuery[DateTime].select(p => ADDDATE(LocalDate.now, DateTime.Interval.YEAR(1)))
+   *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
    * @param date The date to which the addition is to be performed.
@@ -50,8 +50,8 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[Person].select(p => ADDTIME(p.time, LocalTime.of(1, 1, 1, 1)))
-   *   // SELECT ADDTIME(time, '01:01:01.000000001') FROM person
+   *   TableQuery[DateTime].select(p => ADDTIME(p.time, LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT ADDTIME(time, '01:01:01.000000001') FROM date_time
    * }}}
    *
    * @param column The column to which the addition is to be performed.
@@ -67,8 +67,8 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[Person].select(p => ADDTIME(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
-   *   // SELECT ADDTIME('01:01:01.000000001', '01:01:01.000000001') FROM person
+   *   TableQuery[DateTime].select(p => ADDTIME(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT ADDTIME('01:01:01.000000001', '01:01:01.000000001') FROM date_time
    * }}}
    *
    * @param dateTime The date time to which the addition is to be performed.
@@ -78,11 +78,11 @@ trait DateTime:
     Column(s"ADDTIME('${dateTime.toString}', '${time.toString}')")
 
   /**
-   * Function to perform addition on a specified date type column.
+   * Function to convert a date-time value dt from the time zone specified by from_tz to the time zone specified by to_tz.
    *
    * {{{
-   *   TableQuery[Person].select(p => CONVERT_TZ(p.timestampe, LocalTime.of(0, 0), LocalTime.of(9, 0)))
-   *   // SELECT CONVERT_TZ(timestampe, '+00:00', '+09:00') FROM person
+   *   TableQuery[DateTime].select(p => CONVERT_TZ(p.timestampe, LocalTime.of(0, 0), LocalTime.of(9, 0)))
+   *   // SELECT CONVERT_TZ(timestampe, '+00:00', '+09:00') FROM date_time
    * }}}
    *
    * @param column The column to which the addition is to be performed.
@@ -97,11 +97,11 @@ trait DateTime:
     Column(s"CONVERT_TZ(${column.name}, '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")(using column.decoder, column.encoder)
 
   /**
-   * Function to perform addition on a specified date type column.
+   * Function to convert a date-time value dt from the time zone specified by from_tz to the time zone specified by to_tz.
    *
    * {{{
-   *   TableQuery[Person].select(p => CONVERT_TZ(LocalDateTime.of(2025, 1, 1), LocalTime.of(0, 0), LocalTime.of(9, 0)))
-   *   // SELECT CONVERT_TZ('2025-01-01', '+00:00', '+09:00') FROM person
+   *   TableQuery[DateTime].select(p => CONVERT_TZ(LocalDateTime.of(2025, 1, 1), LocalTime.of(0, 0), LocalTime.of(9, 0)))
+   *   // SELECT CONVERT_TZ('2025-01-01', '+00:00', '+09:00') FROM date_time
    * }}}
    *
    * @param dateTime The date time to which the addition is to be performed.
@@ -112,24 +112,50 @@ trait DateTime:
     Column(s"CONVERT_TZ('${dateTime.toString}', '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")
 
   /**
-   * Function to perform addition on a specified date type column.
+   * Function to return the current date as 'YYYY-MM-DD' format.
    *
    * {{{
-   *   TableQuery[Person].select(_ => CURDATE)
-   *   // SELECT CURDATE() FROM person
+   *   TableQuery[DateTime].select(_ => CURDATE)
+   *   // SELECT CURDATE() FROM date_time
    * }}}
    */
   def CURDATE(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] = Column("CURDATE()")
 
   /**
-   * Function to perform addition on a specified date type column.
+   * Function to return the current time in 'hh:mm:ss' format.
    *
    * {{{
-   *   TableQuery[Person].select(_ => CURTIME)
-   *   // SELECT CURTIME() FROM person
+   *   TableQuery[DateTime].select(_ => CURTIME)
+   *   // SELECT CURTIME() FROM date_time
    * }}}
    */
   def CURTIME(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] = Column("CURTIME()")
+  
+  /**
+   * Function to extract the date portion of a date or date-time expression.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DATE(p.timestamp))
+   *   // SELECT DATE(timestamp) FROM date_time
+   * }}}
+   *
+   * @param column Date or date/time column from which to extract the date portion
+   */
+  def DATE[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"DATE(${column.name})")
+
+  /**
+   * Function to extract the date portion of a date or date-time expression.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => DATE(LocalDateTime.of(2025, 1, 1, 1, 1)))
+   *   // SELECT DATE('2025-01-01T01:01') FROM date_time
+   * }}}
+   * @param date
+   *   The date or date-time expression from which the date portion is to be extracted.
+   */
+  def DATE(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime): Column[LocalDate] =
+    Column(s"DATE('${date.toString}')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -25,6 +25,9 @@ trait DateTime:
    *   TableQuery[Person].select(p => ADDDATE(p.birthDate, DateTime.Interval.YEAR(1)))
    *   // SELECT ADDDATE(birth_date, INTERVAL 1 YEAR) FROM person
    * }}}
+   *
+   * @param column The column to which the addition is to be performed.
+   * @param interval The interval to be added to the column.
    */
   def ADDDATE[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
     Column(s"ADDDATE(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
@@ -36,6 +39,9 @@ trait DateTime:
    *   TableQuery[Person].select(p => ADDDATE(LocalDate.now, DateTime.Interval.YEAR(1)))
    *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM person
    * }}}
+   * 
+   * @param date The date to which the addition is to be performed.
+   * @param interval The interval to be added to the date.
    */
   def ADDDATE(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"ADDDATE('${date.toString}', ${interval.statement})")
@@ -45,8 +51,11 @@ trait DateTime:
    *
    * {{{
    *   TableQuery[Person].select(p => ADDTIME(p.time, LocalTime.of(1, 1, 1, 1)))
-   *   // SELECT ADDDATE(time, '01:01:01.000000001') FROM person
+   *   // SELECT ADDTIME(time, '01:01:01.000000001') FROM person
    * }}}
+   * 
+   * @param column The column to which the addition is to be performed.
+   * @param time The time to be added to the column.
    */
   def ADDTIME[A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](
     column: Column[A],
@@ -58,12 +67,49 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[Person].select(p => ADDDATE(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
-   *   // SELECT ADDDATE('01:01:01.000000001', '01:01:01.000000001') FROM person
+   *   TableQuery[Person].select(p => ADDTIME(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT ADDTIME('01:01:01.000000001', '01:01:01.000000001') FROM person
    * }}}
+   * 
+   * @param dateTime The date time to which the addition is to be performed.
+   * @param time The time to be added to the date time.
    */
   def ADDTIME(dateTime: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime, time: LocalTime): Column[LocalTime] =
     Column(s"ADDTIME('${dateTime.toString}', '${time.toString}')")
+
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(p => CONVERT_TZ(p.timestampe, LocalTime.of(0, 0), LocalTime.of(9, 0)))
+   *   // SELECT CONVERT_TZ(timestampe, '+00:00', '+09:00') FROM person
+   * }}}
+   * 
+   * @param column The column to which the addition is to be performed.
+   * @param from The time zone from which the conversion is to be performed.
+   * @param to The time zone to which the conversion is to be performed.
+   */
+  def CONVERT_TZ[A <: LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDateTime | OffsetDateTime | ZonedDateTime]](
+    column: Column[A],
+    from: LocalTime,
+    to: LocalTime
+  ): Column[A] =
+    Column(s"CONVERT_TZ(${column.name}, '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")(using column.decoder, column.encoder)
+
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(p => CONVERT_TZ(LocalDateTime.of(2025, 1, 1), LocalTime.of(0, 0), LocalTime.of(9, 0)))
+   *   // SELECT CONVERT_TZ('2025-01-01', '+00:00', '+09:00') FROM person
+   * }}}
+   * 
+   * @param dateTime The date time to which the addition is to be performed.
+   * @param from The time zone from which the conversion is to be performed.
+   * @param to The time zone to which the conversion is to be performed.
+   */
+  def CONVERT_TZ(dateTime: LocalDateTime | OffsetDateTime | ZonedDateTime, from: LocalTime, to: LocalTime): Column[LocalDateTime] =
+    Column(s"CONVERT_TZ('${dateTime.toString}', '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -240,6 +240,63 @@ trait DateTime:
   def DATE_FORMAT(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime, format: String): Column[String] =
     Column(s"DATE_FORMAT('${date.toString}', '$format')")
 
+  /**
+   * Function to calculate the value of the number of days from one date to another.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DATEDIFF(p.birthDate, p.deathDate))
+   *   // SELECT DATEDIFF(birth_date, death_date) FROM date_time
+   * }}}
+   * 
+   * @param from
+   *   The starting date.
+   * @param to
+   *   The ending date.
+   */
+  def DATEDIFF[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime], B <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+    from: Column[A],
+    to: Column[B]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DATEDIFF(${from.name}, ${to.name})")
+
+  /**
+   * Function to calculate the value of the number of days from one date to another.
+   * 
+   * {{{
+   *  TableQuery[DateTime].select(p => DATEDIFF(p.birthDate, LocalDate.of(2021, 1, 1)))
+   *  // SELECT DATEDIFF(birth_date, '2021-01-01') FROM date_time 
+   * }}}
+   * 
+   * @param from
+   *   The starting date.
+   * @param to
+   *   The ending date.
+   */
+  def DATEDIFF[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+                                                                                                                                                      from: Column[A],
+                                                                                                                                                      to: LocalDate
+                                                                                                                                                    )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DATEDIFF(${from.name}, '${to.toString}')")
+
+  /**
+   * Function to calculate the value of the number of days from one date to another.
+   *
+   * {{{
+   *  TableQuery[DateTime].select(p => DATEDIFF(p.birthDate, LocalDate.of(2021, 1, 1)))
+   *  // SELECT DATEDIFF(birth_date, '2021-01-01') FROM date_time 
+   * }}}
+   *
+   * @param from
+   * The starting date.
+   * @param to
+   * The ending date.
+   */
+  def DATEDIFF(
+                                                                                                                                                      from: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
+                                                                                                                                                      to: LocalDate
+                                                                                                                                                    )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DATEDIFF('${from.toString}', '${to.toString}')")
+    
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -994,6 +994,41 @@ trait DateTime:
     given Codec[LocalTime] = Codec[Int].imap(LocalTime.ofSecondOfDay(_))(_.toSecondOfDay)
     Column(s"SEC_TO_TIME($seconds)")
 
+  /**
+   * Function to return the second part of a date or date-time expression.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(p => SECOND(p.birthDate))
+   *   // SELECT SECOND(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The column from which to extract the second.
+   */
+  def SECOND[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"SECOND(${ column.name })")
+
+  /**
+   * Function to return the second part of a date or date-time expression.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => SECOND(LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT SECOND('2021-01-01 00:00') FROM date_time
+   * }}}
+   * 
+   * @param time
+   *   The date or date-time expression from which to extract the second.
+   */
+  def SECOND(
+    time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"SECOND('${ time.toString.replaceAll("T", " ") }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -752,6 +752,41 @@ trait DateTime:
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
     Column(s"MAKETIME($hour, $minute, $second)")
 
+  /**
+   * Function that returns microseconds from a time or date-time expression as a number in the range 0 to 999999.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MICROSECOND(p.birthDate))
+   *   // SELECT MICROSECOND(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column from which to extract the microseconds.
+   */
+  def MICROSECOND[
+    A <: LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MICROSECOND(${ column.name })")
+
+  /**
+   * Function that returns microseconds from a time or date-time expression as a number in the range 0 to 999999.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => MICROSECOND(LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT MICROSECOND('2021-01-01 00:00') FROM date_time
+   * }}}
+   *
+   * @param datetime
+   *   The date or date-time expression from which to extract the microseconds.
+   */
+  def MICROSECOND(
+    datetime: LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MICROSECOND('${ datetime.toString.replaceAll("T", " ") }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -902,6 +902,16 @@ trait DateTime:
   )(using Decoder[String], Encoder[String]): Column[String] =
     Column(s"MONTHNAME('${ date.toString }')")
 
+  /**
+   * Function to return the current date and time in 'YYYY-MM-DD hh:mm:ss' format.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => NOW)
+   *   // SELECT NOW() FROM date_time
+   * }}}
+   */
+  def NOW()(using Decoder[LocalDateTime], Encoder[LocalDateTime]): Column[LocalDateTime] = Column("NOW()")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -39,7 +39,7 @@ trait DateTime:
    *   TableQuery[Person].select(p => ADDDATE(LocalDate.now, DateTime.Interval.YEAR(1)))
    *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM person
    * }}}
-   * 
+   *
    * @param date The date to which the addition is to be performed.
    * @param interval The interval to be added to the date.
    */
@@ -53,7 +53,7 @@ trait DateTime:
    *   TableQuery[Person].select(p => ADDTIME(p.time, LocalTime.of(1, 1, 1, 1)))
    *   // SELECT ADDTIME(time, '01:01:01.000000001') FROM person
    * }}}
-   * 
+   *
    * @param column The column to which the addition is to be performed.
    * @param time The time to be added to the column.
    */
@@ -70,7 +70,7 @@ trait DateTime:
    *   TableQuery[Person].select(p => ADDTIME(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
    *   // SELECT ADDTIME('01:01:01.000000001', '01:01:01.000000001') FROM person
    * }}}
-   * 
+   *
    * @param dateTime The date time to which the addition is to be performed.
    * @param time The time to be added to the date time.
    */
@@ -84,7 +84,7 @@ trait DateTime:
    *   TableQuery[Person].select(p => CONVERT_TZ(p.timestampe, LocalTime.of(0, 0), LocalTime.of(9, 0)))
    *   // SELECT CONVERT_TZ(timestampe, '+00:00', '+09:00') FROM person
    * }}}
-   * 
+   *
    * @param column The column to which the addition is to be performed.
    * @param from The time zone from which the conversion is to be performed.
    * @param to The time zone to which the conversion is to be performed.
@@ -103,13 +103,23 @@ trait DateTime:
    *   TableQuery[Person].select(p => CONVERT_TZ(LocalDateTime.of(2025, 1, 1), LocalTime.of(0, 0), LocalTime.of(9, 0)))
    *   // SELECT CONVERT_TZ('2025-01-01', '+00:00', '+09:00') FROM person
    * }}}
-   * 
+   *
    * @param dateTime The date time to which the addition is to be performed.
    * @param from The time zone from which the conversion is to be performed.
    * @param to The time zone to which the conversion is to be performed.
    */
   def CONVERT_TZ(dateTime: LocalDateTime | OffsetDateTime | ZonedDateTime, from: LocalTime, to: LocalTime): Column[LocalDateTime] =
     Column(s"CONVERT_TZ('${dateTime.toString}', '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")
+
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(_ => CURDATE)
+   *   // SELECT CURDATE() FROM person
+   * }}}
+   */
+  def CURDATE(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] = Column("CURDATE()")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -369,7 +369,9 @@ trait DateTime:
    * @param date
    *   The date or date-time expression from which to extract the day of the week.
    */
-  def DAYNAME(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[String], Encoder[String]): Column[String] =
+  def DAYNAME(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[String], Encoder[String]): Column[String] =
     Column(s"DAYNAME('${ date.toString }')")
 
   /**
@@ -402,7 +404,9 @@ trait DateTime:
    * @param date
    *   The date or date-time expression from which to extract the day of the month.
    */
-  def DAYOFMONTH(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
+  def DAYOFMONTH(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"DAYOFMONTH('${ date.toString }')")
 
   /**
@@ -421,9 +425,9 @@ trait DateTime:
     A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
       Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
   ](
-     column: Column[A]
-   )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DAYOFWEEK(${column.name})")
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFWEEK(${ column.name })")
 
   /**
    * A function that returns the day of the week for date, in the range 1 to 7, where 1 represents Sunday.
@@ -437,8 +441,10 @@ trait DateTime:
    * @param date
    *   The date or date-time expression from which to extract the day of the week.
    */
-  def DAYOFWEEK(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DAYOFWEEK('${date.toString}')")
+  def DAYOFWEEK(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFWEEK('${ date.toString }')")
 
   /**
    * A function that returns the day of the year for date, in the range 1 to 366.
@@ -456,9 +462,9 @@ trait DateTime:
     A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
       Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
   ](
-     column: Column[A]
-   )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DAYOFYEAR(${column.name})")
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFYEAR(${ column.name })")
 
   /**
    * A function that returns the day of the year for date, in the range 1 to 366.
@@ -472,8 +478,10 @@ trait DateTime:
    * @param date
    *   The date or date-time expression from which to extract the day of the year.
    */
-  def DAYOFYEAR(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DAYOFYEAR('${date.toString}')")
+  def DAYOFYEAR(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFYEAR('${ date.toString }')")
 
   /**
    * A function that returns the time part of the expression expr as a time value.
@@ -487,11 +495,14 @@ trait DateTime:
    * @param timeUnit
    *   The time unit to be extracted.
    */
-  def EXTRACT[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
-    column: Column[A],
-    timeUnit:  DateTime.TimeUnit
+  def EXTRACT[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column:   Column[A],
+    timeUnit: DateTime.TimeUnit
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"EXTRACT(${timeUnit.toString} FROM ${column.name})")
+    Column(s"EXTRACT(${ timeUnit.toString } FROM ${ column.name })")
 
   /**
    * A function that returns the time part of the expression expr as a time value.
@@ -506,10 +517,10 @@ trait DateTime:
    *   The time unit to be extracted.
    */
   def EXTRACT(
-    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
-    timeUnit:  DateTime.TimeUnit
+    date:     LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    timeUnit: DateTime.TimeUnit
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"EXTRACT(${timeUnit.toString} FROM '${date.toString.replaceAll("T", " ")}')")
+    Column(s"EXTRACT(${ timeUnit.toString } FROM '${ date.toString.replaceAll("T", " ") }')")
 
   /**
    * Function to convert a day value to a date.
@@ -526,8 +537,10 @@ trait DateTime:
    * @param column
    *   The column from which to extract the date.
    */
-  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
-    Column(s"FROM_DAYS(${column.name})")
+  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](
+    column: Column[A]
+  )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"FROM_DAYS(${ column.name })")
 
   /**
    * Function to convert a day value to a date.
@@ -544,7 +557,9 @@ trait DateTime:
    * @param days
    *   The number of days from which to extract the date.
    */
-  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](days: A)(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](
+    days: A
+  )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"FROM_DAYS($days)")
 
 object DateTime:
@@ -585,4 +600,6 @@ object DateTime:
    * Time unit for the INTERVAL expression.
    */
   enum TimeUnit:
-    case MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR, SECOND_MICROSECOND, MINUTE_MICROSECOND, MINUTE_SECOND, HOUR_MICROSECOND, HOUR_SECOND, HOUR_MINUTE, DAY_MICROSECOND, DAY_SECOND, DAY_MINUTE, DAY_HOUR, YEAR_MONTH
+    case MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR, SECOND_MICROSECOND, MINUTE_MICROSECOND,
+      MINUTE_SECOND, HOUR_MICROSECOND, HOUR_SECOND, HOUR_MINUTE, DAY_MICROSECOND, DAY_SECOND, DAY_MINUTE, DAY_HOUR,
+      YEAR_MONTH

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -408,12 +408,12 @@ trait DateTime:
   /**
    * A function that returns the day of the week for date, in the range 1 to 7, where 1 represents Sunday.
    * Day of the week index (1 = Sunday, 2 = Monday, ..., 7 = Saturday) for date.
-   * 
+   *
    * {{{
    *  TableQuery[DateTime].select(p => DAYOFWEEK(p.birthDate))
    *  // SELECT DAYOFWEEK(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The date or date-time column from which to extract the day of the week.
    */
@@ -428,17 +428,52 @@ trait DateTime:
   /**
    * A function that returns the day of the week for date, in the range 1 to 7, where 1 represents Sunday.
    * Day of the week index (1 = Sunday, 2 = Monday, ..., 7 = Saturday) for date.
-   * 
+   *
    * {{{
    *  TableQuery[DateTime].select(_ => DAYOFWEEK(LocalDate.of(2021, 1, 1)))
    *  // SELECT DAYOFWEEK('2021-01-01') FROM date_time
    * }}}
-   * 
+   *
    * @param date
    *   The date or date-time expression from which to extract the day of the week.
    */
   def DAYOFWEEK(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"DAYOFWEEK('${date.toString}')")
+
+  /**
+   * A function that returns the day of the year for date, in the range 1 to 366.
+   * The range of DAYOFYEAR() is 1 to 366 because MySQL supports leap year.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DAYOFYEAR(p.birthDate))
+   *   // SELECT DAYOFYEAR(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The date or date-time column from which to extract the day of the year.
+   */
+  def DAYOFYEAR[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+     column: Column[A]
+   )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFYEAR(${column.name})")
+
+  /**
+   * A function that returns the day of the year for date, in the range 1 to 366.
+   * The range of DAYOFYEAR() is 1 to 366 because MySQL supports leap year.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => DAYOFYEAR(LocalDate.of(2021, 1, 1)))
+   *   // SELECT DAYOFYEAR('2021-01-01') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *   The date or date-time expression from which to extract the day of the year.
+   */
+  def DAYOFYEAR(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFYEAR('${date.toString}')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -232,7 +232,7 @@ trait DateTime:
 
   /**
    * Function to format a date value according to the format string.
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/date-and-time-functions.html#function_date-format
+   * @see https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format
    *      
    * {{{
    *   TableQuery[DateTime].select(p => DATE_FORMAT(p.timestamp, "%Y-%m-%d"))
@@ -337,7 +337,7 @@ trait DateTime:
   /**
    * A function that returns the name of the day of the week corresponding to date.
    * The language used for the names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/locale-support.html
+   * @see https://dev.mysql.com/doc/refman/8.0/en/locale-support.html
    *
    * {{{
    *   TableQuery[DateTime].select(p => DAYNAME(p.birthDate))
@@ -359,7 +359,7 @@ trait DateTime:
    * A function that returns the name of the day of the week corresponding to date.
    * The language used for the names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
    *
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/locale-support.html
+   * @see https://dev.mysql.com/doc/refman/8.0/en/locale-support.html
    *
    * {{{
    *   TableQuery[DateTime].select(_ => DAYNAME(LocalDate.of(2021, 1, 1)))
@@ -527,7 +527,7 @@ trait DateTime:
    *
    * Use FROM_DAYS() carefully with older dates. It is not designed to be used with values prior to the advent of the Gregorian calendar (1582).
    *
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/mysql-calendar.html
+   * @see https://dev.mysql.com/doc/refman/8.0/en/mysql-calendar.html
    *
    * {{{
    *   TableQuery[DateTime].select(p => FROM_DAYS(p.birthDate))
@@ -547,7 +547,7 @@ trait DateTime:
    *
    * Use FROM_DAYS() carefully with older dates. It is not designed to be used with values prior to the advent of the Gregorian calendar (1582).
    *
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/mysql-calendar.html
+   * @see https://dev.mysql.com/doc/refman/8.0/en/mysql-calendar.html
    *
    * {{{
    *   TableQuery[DateTime].select(_ => FROM_DAYS(730669))
@@ -861,12 +861,53 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"MONTH('${ date.toString.replaceAll("T", " ") }')")
 
+  /**
+   * Function to return the full name of the month corresponding to a value of type Date.
+   * The language used for names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/en/locale-support.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MONTHNAME(p.birthDate))
+   *   // SELECT MONTHNAME(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The date or date-time column from which to extract the month name.
+   */
+  def MONTHNAME[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"MONTHNAME(${ column.name })")
+
+  /**
+   * Function to return the full name of the month corresponding to a value of type Date.
+   * The language used for names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/en/locale-support.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => MONTHNAME(LocalDate.of(2021, 1, 1)))
+   *   // SELECT MONTHNAME('2021-01-01') FROM date_time
+   * }}}
+   *
+   * @param date
+   *   The date or date-time expression from which to extract the month name.
+   */
+  def MONTHNAME(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"MONTHNAME('${ date.toString }')")
+
 object DateTime:
 
   /**
    * Extracts the date part of a date or datetime expression.
    *
-   * @see https://dev.mysql.com/doc/refman/8.0/ja/expressions.html#temporal-intervals
+   * @see https://dev.mysql.com/doc/refman/8.0/en/expressions.html#temporal-intervals
    *
    *  {{{
    *    INTERVAL expr unit

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -824,6 +824,43 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"MINUTE('${ time.toString.replaceAll("T", " ") }')")
 
+  /**
+   * Function that returns the month part of a date or date-time expression.
+   * The range of the month is 1 to 12.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MONTH(p.birthDate))
+   *   // SELECT MONTH(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *  The column from which to extract the month.
+   */
+  def MONTH[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MONTH(${ column.name })")
+
+  /**
+   * Function that returns the month part of a date or date-time expression.
+   * The range of the month is 1 to 12.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => MONTH(LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT MONTH('2021-01-01 00:00') FROM date_time
+   * }}}
+   *
+   * @param date
+   *  The date or date-time expression from which to extract the month.
+   */
+  def MONTH(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MONTH('${ date.toString.replaceAll("T", " ") }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -22,8 +22,8 @@ trait DateTime:
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[DateTime].select(p => ADDDATE(p.birthDate, DateTime.Interval.YEAR(1)))
-   *   // SELECT ADDDATE(birth_date, INTERVAL 1 YEAR) FROM date_time
+   *   TableQuery[DateTime].select(p => DATE_ADD(p.birthDate, DateTime.Interval.YEAR(1)))
+   *   // SELECT DATE_ADD(birth_date, INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
    * @param column
@@ -31,15 +31,15 @@ trait DateTime:
    * @param interval
    *   The interval to be added to the column.
    */
-  def ADDDATE[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
-    Column(s"ADDDATE(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
+  def DATE_ADD[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
+    Column(s"DATE_ADD(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
 
   /**
    * Function to perform addition on a specified date type column.
    *
    * {{{
-   *   TableQuery[DateTime].select(p => ADDDATE(LocalDate.now, DateTime.Interval.YEAR(1)))
-   *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM date_time
+   *   TableQuery[DateTime].select(p => DATE_ADD(LocalDate.now, DateTime.Interval.YEAR(1)))
+   *   // SELECT DATE_ADD('2008-02-02', INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
    * @param date
@@ -47,8 +47,40 @@ trait DateTime:
    * @param interval
    *   The interval to be added to the date.
    */
-  def ADDDATE(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
-    Column(s"ADDDATE('${date.toString}', ${interval.statement})")
+  def DATE_ADD(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"DATE_ADD('${date.toString}', ${interval.statement})")
+
+  /**
+   * Function to perform subtraction on a given date type column.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DATE_SUB(p.birthDate, DateTime.Interval.YEAR(1)))
+   *   // SELECT DATE_SUB(birth_date, INTERVAL 1 YEAR) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column to which the subtraction is to be performed.
+   * @param interval
+   *   The interval to be subtraction to the column.
+   */
+  def DATE_SUB[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
+    Column(s"DATE_SUB(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
+
+  /**
+   * Function to perform subtraction on a given date.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DATE_SUB(LocalDate.now, DateTime.Interval.YEAR(1)))
+   *   // SELECT DATE_SUB('2008-02-02', INTERVAL 1 YEAR) FROM date_time
+   * }}}
+   *
+   * @param date
+   *   The date to which the subtraction is to be performed.
+   * @param interval
+   *   The interval to be subtraction to the date.
+   */
+  def DATE_SUB(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"DATE_SUB('${date.toString}', ${interval.statement})")
 
   /**
    * Function to perform addition on a specified date type column.

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -448,7 +448,7 @@ trait DateTime:
    *   TableQuery[DateTime].select(p => DAYOFYEAR(p.birthDate))
    *   // SELECT DAYOFYEAR(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The date or date-time column from which to extract the day of the year.
    */
@@ -463,17 +463,53 @@ trait DateTime:
   /**
    * A function that returns the day of the year for date, in the range 1 to 366.
    * The range of DAYOFYEAR() is 1 to 366 because MySQL supports leap year.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(_ => DAYOFYEAR(LocalDate.of(2021, 1, 1)))
    *   // SELECT DAYOFYEAR('2021-01-01') FROM date_time
    * }}}
-   * 
+   *
    * @param date
    *   The date or date-time expression from which to extract the day of the year.
    */
   def DAYOFYEAR(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"DAYOFYEAR('${date.toString}')")
+
+  /**
+   * A function that returns the time part of the expression expr as a time value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => EXTRACT(p.timestamp, DateTime.TimeUnit.HOUR))
+   *   // SELECT EXTRACT(HOUR FROM timestamp) FROM date_time
+   * }}}
+   * @param column
+   *   The column from which to extract the time part.
+   * @param timeUnit
+   *   The time unit to be extracted.
+   */
+  def EXTRACT[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+    column: Column[A],
+    timeUnit:  DateTime.TimeUnit
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"EXTRACT(${timeUnit.toString} FROM ${column.name})")
+
+  /**
+   * A function that returns the time part of the expression expr as a time value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => EXTRACT(LocalDateTime.of(2021, 1, 1, 0, 0), DateTime.TimeUnit.HOUR))
+   *   // SELECT EXTRACT(HOUR FROM '2021-01-01T00:00') FROM date_time
+   * }}}
+   * @param date
+   *   The date or date-time expression from which to extract the time part.
+   * @param timeUnit
+   *   The time unit to be extracted.
+   */
+  def EXTRACT(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    timeUnit:  DateTime.TimeUnit
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"EXTRACT(${timeUnit.toString} FROM '${date.toString.replaceAll("T", " ")}')")
 
 object DateTime:
 
@@ -508,3 +544,9 @@ object DateTime:
     case DAY_MINUTE(expr: String)         extends Interval(expr, "DAY_MINUTE")
     case DAY_HOUR(expr: String)           extends Interval(expr, "DAY_HOUR")
     case YEAR_MONTH(expr: YearMonth)      extends Interval(expr, "YEAR_MONTH")
+
+  /**
+   * Time unit for the INTERVAL expression.
+   */
+  enum TimeUnit:
+    case MICROSECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR, SECOND_MICROSECOND, MINUTE_MICROSECOND, MINUTE_SECOND, HOUR_MICROSECOND, HOUR_SECOND, HOUR_MINUTE, DAY_MICROSECOND, DAY_SECOND, DAY_MINUTE, DAY_HOUR, YEAR_MONTH

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -334,6 +334,44 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"DATEDIFF('${ from.toString }', '${ to.toString }')")
 
+  /**
+   * A function that returns the name of the day of the week corresponding to date.
+   * The language used for the names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
+   * @see https://dev.mysql.com/doc/refman/8.0/ja/locale-support.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => DAYNAME(p.birthDate))
+   *   // SELECT DAYNAME(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The date or date-time column from which to extract the day of the week.
+   */
+  def DAYNAME[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"DAYNAME(${ column.name })")
+
+  /**
+   * A function that returns the name of the day of the week corresponding to date.
+   * The language used for the names is controlled by the value of the lc_time_names system variable (Section 10.16, “Locale Support in MySQL Server”).
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/ja/locale-support.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => DAYNAME(LocalDate.of(2021, 1, 1)))
+   *   // SELECT DAYNAME('2021-01-01') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *   The date or date-time expression from which to extract the day of the week.
+   */
+  def DAYNAME(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"DAYNAME('${ date.toString }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -595,12 +595,12 @@ trait DateTime:
   /**
    * Function for extracting time-only values from date types.
    * The range of returned values is from 0 to 23 for date-time values. However, since the range of TIME values is actually much larger, HOUR can return values greater than 23.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(p => HOUR(p.birthDate))
    *   // SELECT HOUR(birth_date) FROM date_time
    * }}}
-   * 
+   *
    * @param column
    *   The column from which to extract the hour.
    */
@@ -615,7 +615,7 @@ trait DateTime:
   /**
    * Function for extracting time-only values from date types.
    * The range of returned values is from 0 to 23 for date-time values. However, since the range of TIME values is actually much larger, HOUR can return values greater than 23.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(_ => HOUR(LocalTime.of(1, 1, 1, 1)))
    *   // SELECT HOUR('01:01:01.000000001') FROM date_time
@@ -627,6 +627,41 @@ trait DateTime:
     date: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"HOUR('${ date.toString.replaceAll("T", " ") }')")
+
+  /**
+   * Function that returns the value corresponding to the last day of the month from a date or date-time value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => LAST_DAY(p.birthDate))
+   *   // SELECT LAST_DAY(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *  The column from which to extract the last day of the month.
+   */
+  def LAST_DAY[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"LAST_DAY(${ column.name })")
+
+  /**
+   * Function that returns the value corresponding to the last day of the month from a date or date-time value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => LAST_DAY(LocalDate.of(2021, 1, 1)))
+   *   // SELECT LAST_DAY('2021-01-01') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *  The date or date-time expression from which to extract the last day of the month.
+   */
+  def LAST_DAY(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"LAST_DAY('${ date.toString }')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -511,6 +511,42 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"EXTRACT(${timeUnit.toString} FROM '${date.toString.replaceAll("T", " ")}')")
 
+  /**
+   * Function to convert a day value to a date.
+   *
+   * Use FROM_DAYS() carefully with older dates. It is not designed to be used with values prior to the advent of the Gregorian calendar (1582).
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/ja/mysql-calendar.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => FROM_DAYS(p.birthDate))
+   *   // SELECT FROM_DAYS(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column from which to extract the date.
+   */
+  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"FROM_DAYS(${column.name})")
+
+  /**
+   * Function to convert a day value to a date.
+   *
+   * Use FROM_DAYS() carefully with older dates. It is not designed to be used with values prior to the advent of the Gregorian calendar (1582).
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/ja/mysql-calendar.html
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => FROM_DAYS(730669))
+   *   // SELECT FROM_DAYS(730669) FROM date_time
+   * }}}
+   *
+   * @param days
+   *   The number of days from which to extract the date.
+   */
+  def FROM_DAYS[A <: Int | Long | Option[Int | Long]](days: A)(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"FROM_DAYS($days)")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -965,6 +965,35 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"QUARTER('${ date.toString }')")
 
+  /**
+   * Function to convert TIME values to hh:mm:ss format.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => SEC_TO_TIME(p.seconds))
+   *   // SELECT SEC_TO_TIME(seconds) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column to be converted.
+   */
+  def SEC_TO_TIME[A <: Long | Int | Option[Long | Int]](column: Column[A]): Column[LocalTime] =
+    given Codec[LocalTime] = Codec[Int].imap(LocalTime.ofSecondOfDay(_))(_.toSecondOfDay)
+    Column(s"SEC_TO_TIME(${column.name})")
+
+  /**
+   * Function to convert TIME values to hh:mm:ss format.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => SEC_TO_TIME(3600))
+   *   // SELECT SEC_TO_TIME(3600) FROM date_time
+   * }}}
+   * @param seconds
+   *   The number of seconds to be converted.
+   */
+  def SEC_TO_TIME(seconds: Long): Column[LocalTime] =
+    given Codec[LocalTime] = Codec[Int].imap(LocalTime.ofSecondOfDay(_))(_.toSecondOfDay)
+    Column(s"SEC_TO_TIME($seconds)")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -26,8 +26,10 @@ trait DateTime:
    *   // SELECT ADDDATE(birth_date, INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
-   * @param column The column to which the addition is to be performed.
-   * @param interval The interval to be added to the column.
+   * @param column
+   *   The column to which the addition is to be performed.
+   * @param interval
+   *   The interval to be added to the column.
    */
   def ADDDATE[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
     Column(s"ADDDATE(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
@@ -40,8 +42,10 @@ trait DateTime:
    *   // SELECT ADDDATE('2008-02-02', INTERVAL 1 YEAR) FROM date_time
    * }}}
    *
-   * @param date The date to which the addition is to be performed.
-   * @param interval The interval to be added to the date.
+   * @param date
+   *   The date to which the addition is to be performed.
+   * @param interval
+   *   The interval to be added to the date.
    */
   def ADDDATE(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"ADDDATE('${date.toString}', ${interval.statement})")
@@ -54,8 +58,10 @@ trait DateTime:
    *   // SELECT ADDTIME(time, '01:01:01.000000001') FROM date_time
    * }}}
    *
-   * @param column The column to which the addition is to be performed.
-   * @param time The time to be added to the column.
+   * @param column
+   *   The column to which the addition is to be performed.
+   * @param time
+   *   The time to be added to the column.
    */
   def ADDTIME[A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](
     column: Column[A],
@@ -71,8 +77,10 @@ trait DateTime:
    *   // SELECT ADDTIME('01:01:01.000000001', '01:01:01.000000001') FROM date_time
    * }}}
    *
-   * @param dateTime The date time to which the addition is to be performed.
-   * @param time The time to be added to the date time.
+   * @param dateTime
+   *   The date time to which the addition is to be performed.
+   * @param time
+   *   The time to be added to the date time.
    */
   def ADDTIME(dateTime: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime, time: LocalTime): Column[LocalTime] =
     Column(s"ADDTIME('${dateTime.toString}', '${time.toString}')")
@@ -85,9 +93,12 @@ trait DateTime:
    *   // SELECT CONVERT_TZ(timestampe, '+00:00', '+09:00') FROM date_time
    * }}}
    *
-   * @param column The column to which the addition is to be performed.
-   * @param from The time zone from which the conversion is to be performed.
-   * @param to The time zone to which the conversion is to be performed.
+   * @param column
+   *   The column to which the addition is to be performed.
+   * @param from
+   *   The time zone from which the conversion is to be performed.
+   * @param to
+   *   The time zone to which the conversion is to be performed.
    */
   def CONVERT_TZ[A <: LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDateTime | OffsetDateTime | ZonedDateTime]](
     column: Column[A],
@@ -104,9 +115,12 @@ trait DateTime:
    *   // SELECT CONVERT_TZ('2025-01-01', '+00:00', '+09:00') FROM date_time
    * }}}
    *
-   * @param dateTime The date time to which the addition is to be performed.
-   * @param from The time zone from which the conversion is to be performed.
-   * @param to The time zone to which the conversion is to be performed.
+   * @param dateTime
+   *   The date time to which the addition is to be performed.
+   * @param from
+   *   The time zone from which the conversion is to be performed.
+   * @param to
+   *   The time zone to which the conversion is to be performed.
    */
   def CONVERT_TZ(dateTime: LocalDateTime | OffsetDateTime | ZonedDateTime, from: LocalTime, to: LocalTime): Column[LocalDateTime] =
     Column(s"CONVERT_TZ('${dateTime.toString}', '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")
@@ -139,7 +153,8 @@ trait DateTime:
    *   // SELECT DATE(timestamp) FROM date_time
    * }}}
    *
-   * @param column Date or date/time column from which to extract the date portion
+   * @param column
+   *   Date or date/time column from which to extract the date portion
    */
   def DATE[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"DATE(${column.name})")
@@ -156,6 +171,42 @@ trait DateTime:
    */
   def DATE(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime): Column[LocalDate] =
     Column(s"DATE('${date.toString}')")
+
+  /**
+   * Function to format a date value according to the format string.
+   * @see https://dev.mysql.com/doc/refman/8.0/ja/date-and-time-functions.html#function_date-format
+   *      
+   * {{{
+   *   TableQuery[DateTime].select(p => DATE_FORMAT(p.timestamp, "%Y-%m-%d"))
+   *   // SELECT DATE_FORMAT(timestamp, '%Y-%m-%d') FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column to be formatted.
+   * @param format
+   *   The format string.
+   */
+  def DATE_FORMAT[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+    column: Column[A],
+    format: String
+  )(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"DATE_FORMAT(${column.name}, '$format')")
+
+  /**
+   * Function to format a date value according to the format string.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => DATE_FORMAT(LocalDate.of(2025, 1, 1), "%Y-%m-%d"))
+   *   // SELECT DATE_FORMAT('2025-01-01', '%Y-%m-%d') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *   The date or date-time expression to be formatted.
+   * @param format
+   *   The format string.
+   */
+  def DATE_FORMAT(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime, format: String): Column[String] =
+    Column(s"DATE_FORMAT('${date.toString}', '$format')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -787,6 +787,43 @@ trait DateTime:
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
     Column(s"MICROSECOND('${ datetime.toString.replaceAll("T", " ") }')")
 
+  /**
+   * Function that returns the minute part of a date or date-time expression.
+   * The range of the minute is 0 to 59.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MINUTE(p.birthDate))
+   *   // SELECT MINUTE(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *  The column from which to extract the minute.
+   */
+  def MINUTE[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MINUTE(${ column.name })")
+
+  /**
+   * Function that returns the minute part of a date or date-time expression.
+   * The range of the minute is 0 to 59.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => MINUTE(LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT MINUTE('2021-01-01 00:00') FROM date_time
+   * }}}
+   *
+   * @param time
+   *   The date or date-time expression from which to extract the minute.
+   */
+  def MINUTE(
+    time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"MINUTE('${ time.toString.replaceAll("T", " ") }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -40,6 +40,31 @@ trait DateTime:
   def ADDDATE(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"ADDDATE('${date.toString}', ${interval.statement})")
 
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(p => ADDTIME(p.time, LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT ADDDATE(time, '01:01:01.000000001') FROM person
+   * }}}
+   */
+  def ADDTIME[A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+    column: Column[A],
+    time: LocalTime
+  ): Column[A] =
+    Column(s"ADDTIME(${column.name}, '${time.toString}')")(using column.decoder, column.encoder)
+
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(p => ADDDATE(LocalTime.of(1, 1, 1, 1), LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT ADDDATE('01:01:01.000000001', '01:01:01.000000001') FROM person
+   * }}}
+   */
+  def ADDTIME(dateTime: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime, time: LocalTime): Column[LocalTime] =
+    Column(s"ADDTIME('${dateTime.toString}', '${time.toString}')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -680,7 +680,7 @@ trait DateTime:
    */
   def MAKEDATE[A <: Year | Option[Year]](
     column: Column[A],
-    day: Int
+    day:    Int
   )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     require(day > 0, "The annual total must be greater than 0.")
     Column(s"MAKEDATE(${ column.name }, $day)")
@@ -724,11 +724,11 @@ trait DateTime:
     B <: Int | Long | Option[Int | Long],
     C <: Int | Long | Option[Int | Long]
   ](
-    hour: Column[A],
+    hour:   Column[A],
     minute: Column[B],
     second: Column[C]
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
-    Column(s"MAKETIME(${hour.name}, ${minute.name}, ${second.name})")
+    Column(s"MAKETIME(${ hour.name }, ${ minute.name }, ${ second.name })")
 
   /**
    * Function to return a time value calculated from the given hour, minute, and second.
@@ -747,7 +747,7 @@ trait DateTime:
    *   The second from which to calculate the time.
    */
   def MAKETIME(
-    hour: Int | Long,
+    hour:   Int | Long,
     minute: Int | Long,
     second: Int | Long
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
@@ -765,8 +765,7 @@ trait DateTime:
    *   The column from which to extract the microseconds.
    */
   def MICROSECOND[
-    A <: LocalDateTime | OffsetDateTime | ZonedDateTime |
-      Option[LocalDateTime | OffsetDateTime | ZonedDateTime]
+    A <: LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDateTime | OffsetDateTime | ZonedDateTime]
   ](
     column: Column[A]
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
@@ -928,7 +927,7 @@ trait DateTime:
     } { yearMonth =>
       yearMonth.format(formatter)
     }
-    Column(s"PERIOD_ADD(${period.format(formatter)}, $months)")
+    Column(s"PERIOD_ADD(${ period.format(formatter) }, $months)")
 
   /**
    * Function to return the quarter corresponding to date in the range 1 to 4.
@@ -978,7 +977,7 @@ trait DateTime:
    */
   def SEC_TO_TIME[A <: Long | Int | Option[Long | Int]](column: Column[A]): Column[LocalTime] =
     given Codec[LocalTime] = Codec[Int].imap(LocalTime.ofSecondOfDay(_))(_.toSecondOfDay)
-    Column(s"SEC_TO_TIME(${column.name})")
+    Column(s"SEC_TO_TIME(${ column.name })")
 
   /**
    * Function to convert TIME values to hh:mm:ss format.
@@ -1047,10 +1046,10 @@ trait DateTime:
       Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime],
     B <: LocalTime | Option[LocalTime]
   ](
-    time: Column[A],
+    time:     Column[A],
     interval: Column[B]
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
-    Column(s"SUBTIME(${time.name}, ${interval.name})")
+    Column(s"SUBTIME(${ time.name }, ${ interval.name })")
 
   /**
    * Function to calculate the difference time from a date/time or time type value.
@@ -1066,10 +1065,10 @@ trait DateTime:
    *   The end time.
    */
   def SUBTIME(
-    time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    time:     LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime,
     interval: LocalTime
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
-    Column(s"SUBTIME('${time.toString.replaceAll("T", " ")}', '${interval.toString}')")
+    Column(s"SUBTIME('${ time.toString.replaceAll("T", " ") }', '${ interval.toString }')")
 
   /**
    * Function to return the current date and time in 'YYYY-MM-DD hh:mm:ss' format.
@@ -1092,9 +1091,11 @@ trait DateTime:
    * @param column
    *  The column from which to extract the time.
    */
-  def TIME[    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
-    Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](column: Column[A])(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
-    Column(s"TIME(${column.name})")
+  def TIME[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](column: Column[A])(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"TIME(${ column.name })")
 
   /**
    * Function to extract only the time portion from a time or date-time expression value.
@@ -1106,8 +1107,10 @@ trait DateTime:
    * @param time
    *   The time or date-time expression from which to extract the time.
    */
-  def TIME(time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
-    Column(s"TIME('${time.toString.replaceAll("T", " ")}')")
+  def TIME(
+    time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"TIME('${ time.toString.replaceAll("T", " ") }')")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -121,6 +121,16 @@ trait DateTime:
    */
   def CURDATE(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] = Column("CURDATE()")
 
+  /**
+   * Function to perform addition on a specified date type column.
+   *
+   * {{{
+   *   TableQuery[Person].select(_ => CURTIME)
+   *   // SELECT CURTIME() FROM person
+   * }}}
+   */
+  def CURTIME(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] = Column("CURTIME()")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -1081,6 +1081,34 @@ trait DateTime:
    */
   def SYSDATE()(using Decoder[LocalDateTime], Encoder[LocalDateTime]): Column[LocalDateTime] = Column("SYSDATE()")
 
+  /**
+   * Function to extract only the time portion from a time or date-time expression value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => TIME(p.birthDate))
+   *   // SELECT TIME(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *  The column from which to extract the time.
+   */
+  def TIME[    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+    Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](column: Column[A])(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"TIME(${column.name})")
+
+  /**
+   * Function to extract only the time portion from a time or date-time expression value.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => TIME(LocalDateTime.of(2021, 1, 1, 0, 0)))
+   *   // SELECT TIME('2021-01-01 00:00') FROM date_time
+   * }}}
+   * @param time
+   *   The time or date-time expression from which to extract the time.
+   */
+  def TIME(time: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"TIME('${time.toString.replaceAll("T", " ")}')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -9,6 +9,7 @@ package ldbc.statement.functions
 import java.time.*
 
 import ldbc.dsl.codec.*
+
 import ldbc.statement.Column
 
 /**
@@ -32,7 +33,7 @@ trait DateTime:
    *   The interval to be added to the column.
    */
   def DATE_ADD[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
-    Column(s"DATE_ADD(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
+    Column(s"DATE_ADD(${ column.name }, ${ interval.statement })")(using column.decoder, column.encoder)
 
   /**
    * Function to perform addition on a specified date type column.
@@ -47,8 +48,11 @@ trait DateTime:
    * @param interval
    *   The interval to be added to the date.
    */
-  def DATE_ADD(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
-    Column(s"DATE_ADD('${date.toString}', ${interval.statement})")
+  def DATE_ADD(date: LocalDate, interval: DateTime.Interval[Int])(using
+    Decoder[LocalDate],
+    Encoder[LocalDate]
+  ): Column[LocalDate] =
+    Column(s"DATE_ADD('${ date.toString }', ${ interval.statement })")
 
   /**
    * Function to perform subtraction on a given date type column.
@@ -64,7 +68,7 @@ trait DateTime:
    *   The interval to be subtraction to the column.
    */
   def DATE_SUB[A <: LocalDate | Option[LocalDate]](column: Column[A], interval: DateTime.Interval[Int]): Column[A] =
-    Column(s"DATE_SUB(${column.name}, ${interval.statement})")(using column.decoder, column.encoder)
+    Column(s"DATE_SUB(${ column.name }, ${ interval.statement })")(using column.decoder, column.encoder)
 
   /**
    * Function to perform subtraction on a given date.
@@ -79,8 +83,11 @@ trait DateTime:
    * @param interval
    *   The interval to be subtraction to the date.
    */
-  def DATE_SUB(date: LocalDate, interval: DateTime.Interval[Int])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
-    Column(s"DATE_SUB('${date.toString}', ${interval.statement})")
+  def DATE_SUB(date: LocalDate, interval: DateTime.Interval[Int])(using
+    Decoder[LocalDate],
+    Encoder[LocalDate]
+  ): Column[LocalDate] =
+    Column(s"DATE_SUB('${ date.toString }', ${ interval.statement })")
 
   /**
    * Function to perform addition on a specified date type column.
@@ -95,11 +102,14 @@ trait DateTime:
    * @param time
    *   The time to be added to the column.
    */
-  def ADDTIME[A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+  def ADDTIME[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
     column: Column[A],
-    time: LocalTime
+    time:   LocalTime
   ): Column[A] =
-    Column(s"ADDTIME(${column.name}, '${time.toString}')")(using column.decoder, column.encoder)
+    Column(s"ADDTIME(${ column.name }, '${ time.toString }')")(using column.decoder, column.encoder)
 
   /**
    * Function to perform addition on a specified date type column.
@@ -114,8 +124,11 @@ trait DateTime:
    * @param time
    *   The time to be added to the date time.
    */
-  def ADDTIME(dateTime: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime, time: LocalTime): Column[LocalTime] =
-    Column(s"ADDTIME('${dateTime.toString}', '${time.toString}')")
+  def ADDTIME(
+    dateTime: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    time:     LocalTime
+  ): Column[LocalTime] =
+    Column(s"ADDTIME('${ dateTime.toString }', '${ time.toString }')")
 
   /**
    * Function to convert a date-time value dt from the time zone specified by from_tz to the time zone specified by to_tz.
@@ -132,12 +145,16 @@ trait DateTime:
    * @param to
    *   The time zone to which the conversion is to be performed.
    */
-  def CONVERT_TZ[A <: LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDateTime | OffsetDateTime | ZonedDateTime]](
+  def CONVERT_TZ[
+    A <: LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
     column: Column[A],
-    from: LocalTime,
-    to: LocalTime
+    from:   LocalTime,
+    to:     LocalTime
   ): Column[A] =
-    Column(s"CONVERT_TZ(${column.name}, '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")(using column.decoder, column.encoder)
+    Column(
+      s"CONVERT_TZ(${ column.name }, '+${ from.getHour }:${ from.getMinute }', '+${ to.getHour }:${ to.getMinute }')"
+    )(using column.decoder, column.encoder)
 
   /**
    * Function to convert a date-time value dt from the time zone specified by from_tz to the time zone specified by to_tz.
@@ -154,8 +171,14 @@ trait DateTime:
    * @param to
    *   The time zone to which the conversion is to be performed.
    */
-  def CONVERT_TZ(dateTime: LocalDateTime | OffsetDateTime | ZonedDateTime, from: LocalTime, to: LocalTime): Column[LocalDateTime] =
-    Column(s"CONVERT_TZ('${dateTime.toString}', '+${from.getHour}:${from.getMinute}', '+${to.getHour}:${to.getMinute}')")
+  def CONVERT_TZ(
+    dateTime: LocalDateTime | OffsetDateTime | ZonedDateTime,
+    from:     LocalTime,
+    to:       LocalTime
+  ): Column[LocalDateTime] =
+    Column(
+      s"CONVERT_TZ('${ dateTime.toString }', '+${ from.getHour }:${ from.getMinute }', '+${ to.getHour }:${ to.getMinute }')"
+    )
 
   /**
    * Function to return the current date as 'YYYY-MM-DD' format.
@@ -176,7 +199,7 @@ trait DateTime:
    * }}}
    */
   def CURTIME(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] = Column("CURTIME()")
-  
+
   /**
    * Function to extract the date portion of a date or date-time expression.
    *
@@ -188,8 +211,11 @@ trait DateTime:
    * @param column
    *   Date or date/time column from which to extract the date portion
    */
-  def DATE[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
-    Column(s"DATE(${column.name})")
+  def DATE[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](column: Column[A])(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
+    Column(s"DATE(${ column.name })")
 
   /**
    * Function to extract the date portion of a date or date-time expression.
@@ -202,7 +228,7 @@ trait DateTime:
    *   The date or date-time expression from which the date portion is to be extracted.
    */
   def DATE(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime): Column[LocalDate] =
-    Column(s"DATE('${date.toString}')")
+    Column(s"DATE('${ date.toString }')")
 
   /**
    * Function to format a date value according to the format string.
@@ -218,11 +244,14 @@ trait DateTime:
    * @param format
    *   The format string.
    */
-  def DATE_FORMAT[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+  def DATE_FORMAT[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
     column: Column[A],
     format: String
   )(using Decoder[String], Encoder[String]): Column[String] =
-    Column(s"DATE_FORMAT(${column.name}, '$format')")
+    Column(s"DATE_FORMAT(${ column.name }, '$format')")
 
   /**
    * Function to format a date value according to the format string.
@@ -238,7 +267,7 @@ trait DateTime:
    *   The format string.
    */
   def DATE_FORMAT(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime, format: String): Column[String] =
-    Column(s"DATE_FORMAT('${date.toString}', '$format')")
+    Column(s"DATE_FORMAT('${ date.toString }', '$format')")
 
   /**
    * Function to calculate the value of the number of days from one date to another.
@@ -253,11 +282,16 @@ trait DateTime:
    * @param to
    *   The ending date.
    */
-  def DATEDIFF[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime], B <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
+  def DATEDIFF[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime],
+    B <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
     from: Column[A],
-    to: Column[B]
+    to:   Column[B]
   )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DATEDIFF(${from.name}, ${to.name})")
+    Column(s"DATEDIFF(${ from.name }, ${ to.name })")
 
   /**
    * Function to calculate the value of the number of days from one date to another.
@@ -272,11 +306,14 @@ trait DateTime:
    * @param to
    *   The ending date.
    */
-  def DATEDIFF[A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime | Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]](
-                                                                                                                                                      from: Column[A],
-                                                                                                                                                      to: LocalDate
-                                                                                                                                                    )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DATEDIFF(${from.name}, '${to.toString}')")
+  def DATEDIFF[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    from: Column[A],
+    to:   LocalDate
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DATEDIFF(${ from.name }, '${ to.toString }')")
 
   /**
    * Function to calculate the value of the number of days from one date to another.
@@ -292,11 +329,11 @@ trait DateTime:
    * The ending date.
    */
   def DATEDIFF(
-                                                                                                                                                      from: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
-                                                                                                                                                      to: LocalDate
-                                                                                                                                                    )(using Decoder[Int], Encoder[Int]): Column[Int] =
-    Column(s"DATEDIFF('${from.toString}', '${to.toString}')")
-    
+    from: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime,
+    to:   LocalDate
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DATEDIFF('${ from.toString }', '${ to.toString }')")
+
 object DateTime:
 
   /**
@@ -310,23 +347,23 @@ object DateTime:
    */
   enum Interval[A](expr: A, val unit: String):
     def statement: String = s"INTERVAL $expr $unit"
-    case MICROSECOND(expr: Int) extends Interval(expr, "MICROSECOND")
-    case SECOND(expr: Int) extends Interval(expr, "SECOND")
-    case MINUTE(expr: Int) extends Interval(expr, "MINUTE")
-    case HOUR(expr: Int) extends Interval(expr, "HOUR")
-    case DAY(expr: Int) extends Interval(expr, "DAY")
-    case WEEK(expr: Int) extends Interval(expr, "WEEK")
-    case MONTH(expr: Int) extends Interval(expr, "MONTH")
-    case QUARTER(expr: Int) extends Interval(expr, "QUARTER")
-    case YEAR(expr: Int) extends Interval(expr, "YEAR")
+    case MICROSECOND(expr: Int)           extends Interval(expr, "MICROSECOND")
+    case SECOND(expr: Int)                extends Interval(expr, "SECOND")
+    case MINUTE(expr: Int)                extends Interval(expr, "MINUTE")
+    case HOUR(expr: Int)                  extends Interval(expr, "HOUR")
+    case DAY(expr: Int)                   extends Interval(expr, "DAY")
+    case WEEK(expr: Int)                  extends Interval(expr, "WEEK")
+    case MONTH(expr: Int)                 extends Interval(expr, "MONTH")
+    case QUARTER(expr: Int)               extends Interval(expr, "QUARTER")
+    case YEAR(expr: Int)                  extends Interval(expr, "YEAR")
     case SECOND_MICROSECOND(expr: String) extends Interval(expr, "SECOND_MICROSECOND")
     case MINUTE_MICROSECOND(expr: String) extends Interval(expr, "MINUTE_MICROSECOND")
-    case MINUTE_SECOND(expr: String) extends Interval(expr, "MINUTE_SECOND")
-    case HOUR_MICROSECOND(expr: String) extends Interval(expr, "HOUR_MICROSECOND")
-    case HOUR_SECOND(expr: String) extends Interval(expr, "HOUR_SECOND")
-    case HOUR_MINUTE(expr: String) extends Interval(expr, "HOUR_MINUTE")
-    case DAY_MICROSECOND(expr: String) extends Interval(expr, "DAY_MICROSECOND")
-    case DAY_SECOND(expr: String) extends Interval(expr, "DAY_SECOND")
-    case DAY_MINUTE(expr: String) extends Interval(expr, "DAY_MINUTE")
-    case DAY_HOUR(expr: String) extends Interval(expr, "DAY_HOUR")
-    case YEAR_MONTH(expr: YearMonth) extends Interval(expr, "YEAR_MONTH")
+    case MINUTE_SECOND(expr: String)      extends Interval(expr, "MINUTE_SECOND")
+    case HOUR_MICROSECOND(expr: String)   extends Interval(expr, "HOUR_MICROSECOND")
+    case HOUR_SECOND(expr: String)        extends Interval(expr, "HOUR_SECOND")
+    case HOUR_MINUTE(expr: String)        extends Interval(expr, "HOUR_MINUTE")
+    case DAY_MICROSECOND(expr: String)    extends Interval(expr, "DAY_MICROSECOND")
+    case DAY_SECOND(expr: String)         extends Interval(expr, "DAY_SECOND")
+    case DAY_MINUTE(expr: String)         extends Interval(expr, "DAY_MINUTE")
+    case DAY_HOUR(expr: String)           extends Interval(expr, "DAY_HOUR")
+    case YEAR_MONTH(expr: YearMonth)      extends Interval(expr, "YEAR_MONTH")

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -930,6 +930,41 @@ trait DateTime:
     }
     Column(s"PERIOD_ADD(${period.format(formatter)}, $months)")
 
+  /**
+   * Function to return the quarter corresponding to date in the range 1 to 4.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => QUARTER(p.birthDate))
+   *   // SELECT QUARTER(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The date or date-time column from which to extract the quarter.
+   */
+  def QUARTER[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"QUARTER(${ column.name })")
+
+  /**
+   * Function to return the quarter corresponding to date in the range 1 to 4.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => QUARTER(LocalDate.of(2021, 1, 1)))
+   *   // SELECT QUARTER('2021-01-01') FROM date_time
+   * }}}
+   *
+   * @param date
+   *   The date or date-time expression from which to extract the quarter.
+   */
+  def QUARTER(
+    date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"QUARTER('${ date.toString }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -7,6 +7,7 @@
 package ldbc.statement.functions
 
 import java.time.*
+import java.time.format.DateTimeFormatter
 
 import ldbc.dsl.codec.*
 
@@ -911,6 +912,23 @@ trait DateTime:
    * }}}
    */
   def NOW()(using Decoder[LocalDateTime], Encoder[LocalDateTime]): Column[LocalDateTime] = Column("NOW()")
+
+  /**
+   * Function to add the specified month to the yyyyMM value.
+   *
+   * @param period
+   *   The period in yyyyMM format.
+   * @param months
+   *   The number of months to add.
+   */
+  def PERIOD_ADD(period: YearMonth, months: Int): Column[YearMonth] =
+    val formatter = DateTimeFormatter.ofPattern("yyyyMM")
+    given Codec[YearMonth] = Codec[String].imap { str =>
+      YearMonth.parse(str, formatter)
+    } { yearMonth =>
+      yearMonth.format(formatter)
+    }
+    Column(s"PERIOD_ADD(${period.format(formatter)}, $months)")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -372,6 +372,39 @@ trait DateTime:
   def DAYNAME(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[String], Encoder[String]): Column[String] =
     Column(s"DAYNAME('${ date.toString }')")
 
+  /**
+   * A function that returns the day of the month for date, in the range 1 to 31, or 0 for dates such as '0000-00-00' or '2008-00-00' that have a zero day part.
+   * 
+   * {{{
+   *  TableQuery[DateTime].select(p => DAYOFMONTH(p.birthDate))
+   *  // SELECT DAYOFMONTH(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The date or date-time column from which to extract the day of the month.
+   */
+  def DAYOFMONTH[
+    A <: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFMONTH(${ column.name })")
+
+  /**
+   * A function that returns the day of the month for date, in the range 1 to 31, or 0 for dates such as '0000-00-00' or '2008-00-00' that have a zero day part.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => DAYOFMONTH(LocalDate.of(2021, 1, 1)))
+   *   // SELECT DAYOFMONTH('2021-01-01') FROM date_time
+   * }}}
+   * 
+   * @param date
+   *   The date or date-time expression from which to extract the day of the month.
+   */
+  def DAYOFMONTH(date: LocalDate | LocalDateTime | OffsetDateTime | ZonedDateTime)(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"DAYOFMONTH('${ date.toString }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -592,6 +592,42 @@ trait DateTime:
   def FROM_UNIXTIME(timestamp: Int | Long)(using Decoder[String], Encoder[String]): Column[String] =
     Column(s"FROM_UNIXTIME($timestamp)")
 
+  /**
+   * Function for extracting time-only values from date types.
+   * The range of returned values is from 0 to 23 for date-time values. However, since the range of TIME values is actually much larger, HOUR can return values greater than 23.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(p => HOUR(p.birthDate))
+   *   // SELECT HOUR(birth_date) FROM date_time
+   * }}}
+   * 
+   * @param column
+   *   The column from which to extract the hour.
+   */
+  def HOUR[
+    A <: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](
+    column: Column[A]
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"HOUR(${ column.name })")
+
+  /**
+   * Function for extracting time-only values from date types.
+   * The range of returned values is from 0 to 23 for date-time values. However, since the range of TIME values is actually much larger, HOUR can return values greater than 23.
+   * 
+   * {{{
+   *   TableQuery[DateTime].select(_ => HOUR(LocalTime.of(1, 1, 1, 1)))
+   *   // SELECT HOUR('01:01:01.000000001') FROM date_time
+   * }}}
+   * @param date
+   *   The date or date-time expression from which to extract the hour.
+   */
+  def HOUR(
+    date: LocalTime | LocalDateTime | OffsetDateTime | ZonedDateTime
+  )(using Decoder[Int], Encoder[Int]): Column[Int] =
+    Column(s"HOUR('${ date.toString.replaceAll("T", " ") }')")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -1031,12 +1031,12 @@ trait DateTime:
 
   /**
    * Function to calculate the difference time from a date/time or time type value.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(p => SEC_TO_TIME(p.start, p.end))
    *   // SELECT SEC_TO_TIME(start, end) FROM date_time
    * }}}
-   * 
+   *
    * @param time
    *   The start time.
    * @param interval
@@ -1054,12 +1054,12 @@ trait DateTime:
 
   /**
    * Function to calculate the difference time from a date/time or time type value.
-   * 
+   *
    * {{{
    *   TableQuery[DateTime].select(_ => SUBTIME(LocalDateTime.of(2021, 1, 1, 0, 0), LocalDateTime.of(2021, 1, 1, 0, 0)))
    *   // SELECT SUBTIME('2021-01-01 00:00', '2021-01-01 00:00') FROM date_time
    * }}}
-   * 
+   *
    * @param time
    *   The start time.
    * @param interval
@@ -1070,6 +1070,16 @@ trait DateTime:
     interval: LocalTime
   )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
     Column(s"SUBTIME('${time.toString.replaceAll("T", " ")}', '${interval.toString}')")
+
+  /**
+   * Function to return the current date and time in 'YYYY-MM-DD hh:mm:ss' format.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => SYSDATE)
+   *   // SELECT SYSDATE() FROM date_time
+   * }}}
+   */
+  def SYSDATE()(using Decoder[LocalDateTime], Encoder[LocalDateTime]): Column[LocalDateTime] = Column("SYSDATE()")
 
 object DateTime:
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -702,6 +702,56 @@ trait DateTime:
     require(day > 0, "The annual total must be greater than 0.")
     Column(s"MAKEDATE($year, $day)")
 
+  /**
+   * Function to return a time value calculated from the given hour, minute, and second.
+   * The range of the hour is 0 to 23, the range of the minute is 0 to 59, and the range of the second is 0 to 59.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => MAKETIME(p.hour, p.minute, p.second))
+   *   // SELECT MAKETIME(hour, minute, second) FROM date_time
+   * }}}
+   *
+   * @param hour
+   *   The hour from which to calculate the time.
+   * @param minute
+   *   The minute from which to calculate the time.
+   * @param second
+   *   The second from which to calculate the time.
+   */
+  def MAKETIME[
+    A <: Int | Long | Option[Int | Long],
+    B <: Int | Long | Option[Int | Long],
+    C <: Int | Long | Option[Int | Long]
+  ](
+    hour: Column[A],
+    minute: Column[B],
+    second: Column[C]
+  )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"MAKETIME(${hour.name}, ${minute.name}, ${second.name})")
+
+  /**
+   * Function to return a time value calculated from the given hour, minute, and second.
+   * The range of the hour is 0 to 23, the range of the minute is 0 to 59, and the range of the second is 0 to 59.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(_ => MAKETIME(1, 1, 1))
+   *   // SELECT MAKETIME(1, 1, 1) FROM date_time
+   * }}}
+   *
+   * @param hour
+   *   The hour from which to calculate the time.
+   * @param minute
+   *   The minute from which to calculate the time.
+   * @param second
+   *   The second from which to calculate the time.
+   */
+  def MAKETIME(
+    hour: Int | Long,
+    minute: Int | Long,
+    second: Int | Long
+  )(using Decoder[LocalTime], Encoder[LocalTime]): Column[LocalTime] =
+    Column(s"MAKETIME($hour, $minute, $second)")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/functions/DateTime.scala
@@ -562,6 +562,36 @@ trait DateTime:
   )(using Decoder[LocalDate], Encoder[LocalDate]): Column[LocalDate] =
     Column(s"FROM_DAYS($days)")
 
+  /**
+   * Function to generate a UTC date in YYYYY-MM-DD hh:mm:ss format from a number.
+   *
+   * {{{
+   *   TableQuery[DateTime].select(p => FROM_UNIXTIME(p.birthDate))
+   *   // SELECT FROM_UNIXTIME(birth_date) FROM date_time
+   * }}}
+   *
+   * @param column
+   *   The column from which to extract the date.
+   */
+  def FROM_UNIXTIME[A <: Int | Long | Option[Int | Long]](
+    column: Column[A]
+  )(using Decoder[LocalDateTime], Encoder[LocalDateTime]): Column[LocalDateTime] =
+    Column(s"FROM_UNIXTIME(${ column.name })")
+
+  /**
+   * Function to generate a UTC date in YYYYY-MM-DD hh:mm:ss format from a number.
+   *
+   * {{{
+   *  TableQuery[DateTime].select(_ => FROM_UNIXTIME(1612137600))
+   *  // SELECT FROM_UNIXTIME(1612137600) FROM date_time
+   * }}}
+   *
+   * @param timestamp
+   *   The number from which to extract the date.
+   */
+  def FROM_UNIXTIME(timestamp: Int | Long)(using Decoder[String], Encoder[String]): Column[String] =
+    Column(s"FROM_UNIXTIME($timestamp)")
+
 object DateTime:
 
   /**

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -220,3 +220,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(SECOND(c6).name == "SECOND(local_date_time)")
     assert(SECOND(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "SECOND('2021-01-01 00:00')")
   }
+
+  it should "Statement generated using the SUBTIME function matches the specified string." in {
+    assert(SUBTIME(c5, c3).name == "SUBTIME(local_date_time, local_time)")
+    assert(SUBTIME(c6, c4).name == "SUBTIME(local_date_time, local_time)")
+    assert(SUBTIME(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(1, 1, 1, 1)).name == "SUBTIME('2021-01-01 00:00', '01:01:01.000000001')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -59,3 +59,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DATE(c6).name == "DATE(local_date_time)")
     assert(DATE(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "DATE('2021-01-01T00:00')")
   }
+
+  it should "Statement generated using the DATE_FORMAT function matches the specified string." in {
+    assert(DATE_FORMAT(c5, "%Y-%m-%d").name == "DATE_FORMAT(local_date_time, '%Y-%m-%d')")
+    assert(DATE_FORMAT(c6, "%Y-%m-%d").name == "DATE_FORMAT(local_date_time, '%Y-%m-%d')")
+    assert(DATE_FORMAT(LocalDateTime.of(2021, 1, 1, 0, 0), "%Y-%m-%d").name == "DATE_FORMAT('2021-01-01T00:00', '%Y-%m-%d')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -188,3 +188,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MONTH(c6).name == "MONTH(local_date_time)")
     assert(MONTH(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MONTH('2021-01-01 00:00')")
   }
+
+  it should "Statement generated using the MONTHNAME function matches the specified string." in {
+    assert(MONTHNAME(c5).name == "MONTHNAME(local_date_time)")
+    assert(MONTHNAME(c6).name == "MONTHNAME(local_date_time)")
+    assert(MONTHNAME(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MONTHNAME('2021-01-01T00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -19,6 +19,8 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   private val c2 = Column.Impl[Option[LocalDate]]("local_date")
   private val c3 = Column.Impl[LocalTime]("local_time")
   private val c4 = Column.Impl[Option[LocalTime]]("local_time")
+  private val c5 = Column.Impl[LocalDateTime]("local_date_time")
+  private val c6 = Column.Impl[Option[LocalDateTime]]("local_date_time")
 
   it should "Statement generated using the ADDDATE function matches the specified string." in {
     assert(ADDDATE(c1, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
@@ -36,4 +38,11 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(ADDTIME(c3, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
     assert(ADDTIME(c4, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
     assert(ADDTIME(LocalTime.of(1, 1, 1), LocalTime.of(1, 1, 1, 1)).name == "ADDTIME('01:01:01', '01:01:01.000000001')")
+  }
+
+
+  it should "Statement generated using the CONVERT_TZ function matches the specified string." in {
+    assert(CONVERT_TZ(c5, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
+    assert(CONVERT_TZ(c6, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
+    assert(CONVERT_TZ(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ('2021-01-01T00:00', '+0:0', '+9:0')")
   }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -226,3 +226,7 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(SUBTIME(c6, c4).name == "SUBTIME(local_date_time, local_time)")
     assert(SUBTIME(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(1, 1, 1, 1)).name == "SUBTIME('2021-01-01 00:00', '01:01:01.000000001')")
   }
+
+  it should "Statement generated using the SYSDATE function matches the specified string." in {
+    assert(SYSDATE().name == "SYSDATE()")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -15,15 +15,15 @@ import ldbc.statement.Column
 
 class DateTimeTest extends AnyFlatSpec, DateTime:
 
-  private val c1 = Column.Impl[LocalDate]("local_date")
-  private val c2 = Column.Impl[Option[LocalDate]]("local_date")
-  private val c3 = Column.Impl[LocalTime]("local_time")
-  private val c4 = Column.Impl[Option[LocalTime]]("local_time")
-  private val c5 = Column.Impl[LocalDateTime]("local_date_time")
-  private val c6 = Column.Impl[Option[LocalDateTime]]("local_date_time")
-  private val c7 = Column.Impl[Int]("days")
-  private val c8 = Column.Impl[Option[Int]]("days")
-  private val c9 = Column.Impl[Year]("year")
+  private val c1  = Column.Impl[LocalDate]("local_date")
+  private val c2  = Column.Impl[Option[LocalDate]]("local_date")
+  private val c3  = Column.Impl[LocalTime]("local_time")
+  private val c4  = Column.Impl[Option[LocalTime]]("local_time")
+  private val c5  = Column.Impl[LocalDateTime]("local_date_time")
+  private val c6  = Column.Impl[Option[LocalDateTime]]("local_date_time")
+  private val c7  = Column.Impl[Int]("days")
+  private val c8  = Column.Impl[Option[Int]]("days")
+  private val c9  = Column.Impl[Year]("year")
   private val c10 = Column.Impl[Option[Year]]("year")
   private val c11 = Column.Impl[Int]("hour")
   private val c12 = Column.Impl[Option[Int]]("hour")
@@ -224,7 +224,12 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the SUBTIME function matches the specified string." in {
     assert(SUBTIME(c5, c3).name == "SUBTIME(local_date_time, local_time)")
     assert(SUBTIME(c6, c4).name == "SUBTIME(local_date_time, local_time)")
-    assert(SUBTIME(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(1, 1, 1, 1)).name == "SUBTIME('2021-01-01 00:00', '01:01:01.000000001')")
+    assert(
+      SUBTIME(
+        LocalDateTime.of(2021, 1, 1, 0, 0),
+        LocalTime.of(1, 1, 1, 1)
+      ).name == "SUBTIME('2021-01-01 00:00', '01:01:01.000000001')"
+    )
   }
 
   it should "Statement generated using the SYSDATE function matches the specified string." in {

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -117,3 +117,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DAYOFYEAR(c6).name == "DAYOFYEAR(local_date_time)")
     assert(DAYOFYEAR(LocalDate.of(2025, 1, 1)).name == "DAYOFYEAR('2025-01-01')")
   }
+
+  it should "Statement generated using the EXTRACT function matches the specified string." in {
+    assert(EXTRACT(c5, TimeUnit.YEAR).name == "EXTRACT(YEAR FROM local_date_time)")
+    assert(EXTRACT(c6, TimeUnit.MONTH).name == "EXTRACT(MONTH FROM local_date_time)")
+    assert(EXTRACT(LocalDate.of(2025, 1, 1), TimeUnit.HOUR).name == "EXTRACT(HOUR FROM '2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -170,3 +170,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MAKETIME(c12, c14, c16).name == "MAKETIME(hour, minute, second)")
     assert(MAKETIME(24, 59, 59).name == "MAKETIME(24, 59, 59)")
   }
+
+  it should "Statement generated using the MICROSECOND function matches the specified string." in {
+    assert(MICROSECOND(c5).name == "MICROSECOND(local_date_time)")
+    assert(MICROSECOND(c6).name == "MICROSECOND(local_date_time)")
+    assert(MICROSECOND(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MICROSECOND('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -23,6 +23,8 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   private val c6 = Column.Impl[Option[LocalDateTime]]("local_date_time")
   private val c7 = Column.Impl[Int]("days")
   private val c8 = Column.Impl[Option[Int]]("days")
+  private val c9 = Column.Impl[Year]("year")
+  private val c10 = Column.Impl[Option[Year]]("year")
 
   it should "Statement generated using the DATE_ADD function matches the specified string." in {
     assert(DATE_ADD(c1, Interval.DAY(1)).name == "DATE_ADD(local_date, INTERVAL 1 DAY)")
@@ -148,4 +150,11 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(LAST_DAY(c5).name == "LAST_DAY(local_date_time)")
     assert(LAST_DAY(c6).name == "LAST_DAY(local_date_time)")
     assert(LAST_DAY(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "LAST_DAY('2021-01-01T00:00')")
+  }
+
+  it should "Statement generated using the MAKEDATE function matches the specified string." in {
+    assert(MAKEDATE(c9, 31).name == "MAKEDATE(year, 31)")
+    assert(MAKEDATE(c10, 64).name == "MAKEDATE(year, 64)")
+    assert(MAKEDATE(2025, 103).name == "MAKEDATE(2025, 103)")
+    assert(MAKEDATE(Year.of(2025), 103).name == "MAKEDATE(2025, 103)")
   }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -176,3 +176,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MICROSECOND(c6).name == "MICROSECOND(local_date_time)")
     assert(MICROSECOND(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MICROSECOND('2021-01-01 00:00')")
   }
+
+  it should "Statement generated using the MINUTE function matches the specified string." in {
+    assert(MINUTE(c5).name == "MINUTE(local_date_time)")
+    assert(MINUTE(c6).name == "MINUTE(local_date_time)")
+    assert(MINUTE(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MINUTE('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -21,6 +21,8 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   private val c4 = Column.Impl[Option[LocalTime]]("local_time")
   private val c5 = Column.Impl[LocalDateTime]("local_date_time")
   private val c6 = Column.Impl[Option[LocalDateTime]]("local_date_time")
+  private val c7 = Column.Impl[Int]("days")
+  private val c8 = Column.Impl[Option[Int]]("days")
 
   it should "Statement generated using the DATE_ADD function matches the specified string." in {
     assert(DATE_ADD(c1, Interval.DAY(1)).name == "DATE_ADD(local_date, INTERVAL 1 DAY)")
@@ -122,4 +124,10 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(EXTRACT(c5, TimeUnit.YEAR).name == "EXTRACT(YEAR FROM local_date_time)")
     assert(EXTRACT(c6, TimeUnit.MONTH).name == "EXTRACT(MONTH FROM local_date_time)")
     assert(EXTRACT(LocalDate.of(2025, 1, 1), TimeUnit.HOUR).name == "EXTRACT(HOUR FROM '2025-01-01')")
+  }
+
+  it should "Statement generated using the FROM_DAYS function matches the specified string." in {
+    assert(FROM_DAYS(c7).name == "FROM_DAYS(days)")
+    assert(FROM_DAYS(c8).name == "FROM_DAYS(days)")
+    assert(FROM_DAYS(730669).name == "FROM_DAYS(730669)")
   }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -93,3 +93,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DATEDIFF(c6, LocalDate.of(2025, 1, 1)).name == "DATEDIFF(local_date_time, '2025-01-01')")
     assert(DATEDIFF(LocalDate.of(2024, 1, 1), LocalDate.of(2025, 1, 1)).name == "DATEDIFF('2024-01-01', '2025-01-01')")
   }
+
+  it should "Statement generated using the DAYNAME function matches the specified string." in {
+    assert(DAYNAME(c5).name == "DAYNAME(local_date_time)")
+    assert(DAYNAME(c6).name == "DAYNAME(local_date_time)")
+    assert(DAYNAME(LocalDate.of(2025, 1, 1)).name == "DAYNAME('2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -198,3 +198,7 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the NOW function matches the specified string." in {
     assert(NOW().name == "NOW()")
   }
+
+  it should "Statement generated using the PERIOD_ADD function matches the specified string." in {
+    assert(PERIOD_ADD(YearMonth.of(2025, 1), 1).name == "PERIOD_ADD(202501, 1)")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -137,3 +137,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(FROM_UNIXTIME(c8).name == "FROM_UNIXTIME(days)")
     assert(FROM_UNIXTIME(730669).name == "FROM_UNIXTIME(730669)")
   }
+
+  it should "Statement generated using the HOUR function matches the specified string." in {
+    assert(HOUR(c5).name == "HOUR(local_date_time)")
+    assert(HOUR(c6).name == "HOUR(local_date_time)")
+    assert(HOUR(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "HOUR('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -49,3 +49,7 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the CURDATE function matches the specified string." in {
     assert(CURDATE.name == "CURDATE()")
   }
+
+  it should "Statement generated using the CURTIME function matches the specified string." in {
+    assert(CURTIME.name == "CURTIME()")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -202,3 +202,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the PERIOD_ADD function matches the specified string." in {
     assert(PERIOD_ADD(YearMonth.of(2025, 1), 1).name == "PERIOD_ADD(202501, 1)")
   }
+
+  it should "Statement generated using the QUARTER function matches the specified string." in {
+    assert(QUARTER(c5).name == "QUARTER(local_date_time)")
+    assert(QUARTER(c6).name == "QUARTER(local_date_time)")
+    assert(QUARTER(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "QUARTER('2021-01-01T00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.statement.functions
+
+import java.time.*
+
+import ldbc.statement.Column
+import ldbc.statement.functions.DateTime.*
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DateTimeTest extends AnyFlatSpec, DateTime:
+
+  private val c1 = Column.Impl[LocalDate]("local_date")
+  private val c2 = Column.Impl[Option[LocalDate]]("local_date")
+  
+  it should "Statement generated using the ADDDATE function matches the specified string." in {
+    assert(ADDDATE(c1, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
+    assert(ADDDATE(c1, Interval.MONTH(1)).name == "ADDDATE(local_date, INTERVAL 1 MONTH)")
+    assert(ADDDATE(c1, Interval.YEAR(1)).name == "ADDDATE(local_date, INTERVAL 1 YEAR)")
+    assert(ADDDATE(c2, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
+    assert(ADDDATE(c2, Interval.MONTH(1)).name == "ADDDATE(local_date, INTERVAL 1 MONTH)")
+    assert(ADDDATE(c2, Interval.YEAR(1)).name == "ADDDATE(local_date, INTERVAL 1 YEAR)")
+    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.DAY(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 DAY)")
+    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.MONTH(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 MONTH)")
+    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 YEAR)")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -22,17 +22,30 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   private val c5 = Column.Impl[LocalDateTime]("local_date_time")
   private val c6 = Column.Impl[Option[LocalDateTime]]("local_date_time")
 
-  it should "Statement generated using the ADDDATE function matches the specified string." in {
-    assert(ADDDATE(c1, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
-    assert(ADDDATE(c1, Interval.MONTH(1)).name == "ADDDATE(local_date, INTERVAL 1 MONTH)")
-    assert(ADDDATE(c1, Interval.YEAR(1)).name == "ADDDATE(local_date, INTERVAL 1 YEAR)")
-    assert(ADDDATE(c2, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
-    assert(ADDDATE(c2, Interval.MONTH(1)).name == "ADDDATE(local_date, INTERVAL 1 MONTH)")
-    assert(ADDDATE(c2, Interval.YEAR(1)).name == "ADDDATE(local_date, INTERVAL 1 YEAR)")
-    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.DAY(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 DAY)")
-    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.MONTH(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 MONTH)")
-    assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 YEAR)")
+  it should "Statement generated using the DATE_ADD function matches the specified string." in {
+    assert(DATE_ADD(c1, Interval.DAY(1)).name == "DATE_ADD(local_date, INTERVAL 1 DAY)")
+    assert(DATE_ADD(c1, Interval.MONTH(1)).name == "DATE_ADD(local_date, INTERVAL 1 MONTH)")
+    assert(DATE_ADD(c1, Interval.YEAR(1)).name == "DATE_ADD(local_date, INTERVAL 1 YEAR)")
+    assert(DATE_ADD(c2, Interval.DAY(1)).name == "DATE_ADD(local_date, INTERVAL 1 DAY)")
+    assert(DATE_ADD(c2, Interval.MONTH(1)).name == "DATE_ADD(local_date, INTERVAL 1 MONTH)")
+    assert(DATE_ADD(c2, Interval.YEAR(1)).name == "DATE_ADD(local_date, INTERVAL 1 YEAR)")
+    assert(DATE_ADD(LocalDate.of(2021, 1, 1), Interval.DAY(1)).name == "DATE_ADD('2021-01-01', INTERVAL 1 DAY)")
+    assert(DATE_ADD(LocalDate.of(2021, 1, 1), Interval.MONTH(1)).name == "DATE_ADD('2021-01-01', INTERVAL 1 MONTH)")
+    assert(DATE_ADD(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "DATE_ADD('2021-01-01', INTERVAL 1 YEAR)")
   }
+
+  it should "Statement generated using the DATE_SUB function matches the specified string." in {
+    assert(DATE_SUB(c1, Interval.DAY(1)).name == "DATE_SUB(local_date, INTERVAL 1 DAY)")
+    assert(DATE_SUB(c1, Interval.MONTH(1)).name == "DATE_SUB(local_date, INTERVAL 1 MONTH)")
+    assert(DATE_SUB(c1, Interval.YEAR(1)).name == "DATE_SUB(local_date, INTERVAL 1 YEAR)")
+    assert(DATE_SUB(c2, Interval.DAY(1)).name == "DATE_SUB(local_date, INTERVAL 1 DAY)")
+    assert(DATE_SUB(c2, Interval.MONTH(1)).name == "DATE_SUB(local_date, INTERVAL 1 MONTH)")
+    assert(DATE_SUB(c2, Interval.YEAR(1)).name == "DATE_SUB(local_date, INTERVAL 1 YEAR)")
+    assert(DATE_SUB(LocalDate.of(2021, 1, 1), Interval.DAY(1)).name == "DATE_SUB('2021-01-01', INTERVAL 1 DAY)")
+    assert(DATE_SUB(LocalDate.of(2021, 1, 1), Interval.MONTH(1)).name == "DATE_SUB('2021-01-01', INTERVAL 1 MONTH)")
+    assert(DATE_SUB(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "DATE_SUB('2021-01-01', INTERVAL 1 YEAR)")
+  }
+
 
   it should "Statement generated using the ADDTIME function matches the specified string." in {
     assert(ADDTIME(c3, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -99,3 +99,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DAYNAME(c6).name == "DAYNAME(local_date_time)")
     assert(DAYNAME(LocalDate.of(2025, 1, 1)).name == "DAYNAME('2025-01-01')")
   }
+
+  it should "Statement generated using the DAYOFMONTH function matches the specified string." in {
+    assert(DAYOFMONTH(c5).name == "DAYOFMONTH(local_date_time)")
+    assert(DAYOFMONTH(c6).name == "DAYOFMONTH(local_date_time)")
+    assert(DAYOFMONTH(LocalDate.of(2025, 1, 1)).name == "DAYOFMONTH('2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -208,3 +208,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(QUARTER(c6).name == "QUARTER(local_date_time)")
     assert(QUARTER(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "QUARTER('2021-01-01T00:00')")
   }
+
+  it should "Statement generated using the SEC_TO_TIME function matches the specified string." in {
+    assert(SEC_TO_TIME(c15).name == "SEC_TO_TIME(second)")
+    assert(SEC_TO_TIME(c16).name == "SEC_TO_TIME(second)")
+    assert(SEC_TO_TIME(2378).name == "SEC_TO_TIME(2378)")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -214,3 +214,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(SEC_TO_TIME(c16).name == "SEC_TO_TIME(second)")
     assert(SEC_TO_TIME(2378).name == "SEC_TO_TIME(2378)")
   }
+
+  it should "Statement generated using the SECOND function matches the specified string." in {
+    assert(SECOND(c5).name == "SECOND(local_date_time)")
+    assert(SECOND(c6).name == "SECOND(local_date_time)")
+    assert(SECOND(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "SECOND('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -230,3 +230,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the SYSDATE function matches the specified string." in {
     assert(SYSDATE().name == "SYSDATE()")
   }
+
+  it should "Statement generated using the TIME function matches the specified string." in {
+    assert(TIME(c5).name == "TIME(local_date_time)")
+    assert(TIME(c6).name == "TIME(local_date_time)")
+    assert(TIME(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "TIME('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -17,7 +17,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
 
   private val c1 = Column.Impl[LocalDate]("local_date")
   private val c2 = Column.Impl[Option[LocalDate]]("local_date")
-  
+  private val c3 = Column.Impl[LocalTime]("local_time")
+  private val c4 = Column.Impl[Option[LocalTime]]("local_time")
+
   it should "Statement generated using the ADDDATE function matches the specified string." in {
     assert(ADDDATE(c1, Interval.DAY(1)).name == "ADDDATE(local_date, INTERVAL 1 DAY)")
     assert(ADDDATE(c1, Interval.MONTH(1)).name == "ADDDATE(local_date, INTERVAL 1 MONTH)")
@@ -28,4 +30,10 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.DAY(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 DAY)")
     assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.MONTH(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 MONTH)")
     assert(ADDDATE(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "ADDDATE('2021-01-01', INTERVAL 1 YEAR)")
+  }
+
+  it should "Statement generated using the ADDTIME function matches the specified string." in {
+    assert(ADDTIME(c3, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
+    assert(ADDTIME(c4, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
+    assert(ADDTIME(LocalTime.of(1, 1, 1), LocalTime.of(1, 1, 1, 1)).name == "ADDTIME('01:01:01', '01:01:01.000000001')")
   }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -143,3 +143,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(HOUR(c6).name == "HOUR(local_date_time)")
     assert(HOUR(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "HOUR('2021-01-01 00:00')")
   }
+
+  it should "Statement generated using the LAST_DAY function matches the specified string." in {
+    assert(LAST_DAY(c5).name == "LAST_DAY(local_date_time)")
+    assert(LAST_DAY(c6).name == "LAST_DAY(local_date_time)")
+    assert(LAST_DAY(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "LAST_DAY('2021-01-01T00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -25,6 +25,12 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   private val c8 = Column.Impl[Option[Int]]("days")
   private val c9 = Column.Impl[Year]("year")
   private val c10 = Column.Impl[Option[Year]]("year")
+  private val c11 = Column.Impl[Int]("hour")
+  private val c12 = Column.Impl[Option[Int]]("hour")
+  private val c13 = Column.Impl[Int]("minute")
+  private val c14 = Column.Impl[Option[Int]]("minute")
+  private val c15 = Column.Impl[Int]("second")
+  private val c16 = Column.Impl[Option[Int]]("second")
 
   it should "Statement generated using the DATE_ADD function matches the specified string." in {
     assert(DATE_ADD(c1, Interval.DAY(1)).name == "DATE_ADD(local_date, INTERVAL 1 DAY)")
@@ -157,4 +163,10 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MAKEDATE(c10, 64).name == "MAKEDATE(year, 64)")
     assert(MAKEDATE(2025, 103).name == "MAKEDATE(2025, 103)")
     assert(MAKEDATE(Year.of(2025), 103).name == "MAKEDATE(2025, 103)")
+  }
+
+  it should "Statement generated using the MAKETIME function matches the specified string." in {
+    assert(MAKETIME(c11, c13, c15).name == "MAKETIME(hour, minute, second)")
+    assert(MAKETIME(c12, c14, c16).name == "MAKETIME(hour, minute, second)")
+    assert(MAKETIME(24, 59, 59).name == "MAKETIME(24, 59, 59)")
   }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -78,3 +78,11 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DATE_FORMAT(c6, "%Y-%m-%d").name == "DATE_FORMAT(local_date_time, '%Y-%m-%d')")
     assert(DATE_FORMAT(LocalDateTime.of(2021, 1, 1, 0, 0), "%Y-%m-%d").name == "DATE_FORMAT('2021-01-01T00:00', '%Y-%m-%d')")
   }
+
+  it should "Statement generated using the DATEDIFF function matches the specified string." in {
+    assert(DATEDIFF(c5, c1).name == "DATEDIFF(local_date_time, local_date)")
+    assert(DATEDIFF(c6, c2).name == "DATEDIFF(local_date_time, local_date)")
+    assert(DATEDIFF(c5, LocalDate.of(2025, 1, 1)).name == "DATEDIFF(local_date_time, '2025-01-01')")
+    assert(DATEDIFF(c6, LocalDate.of(2025, 1, 1)).name == "DATEDIFF(local_date_time, '2025-01-01')")
+    assert(DATEDIFF(LocalDate.of(2024, 1, 1), LocalDate.of(2025, 1, 1)).name == "DATEDIFF('2024-01-01', '2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -8,10 +8,10 @@ package ldbc.statement.functions
 
 import java.time.*
 
-import ldbc.statement.Column
-import ldbc.statement.functions.DateTime.*
-
 import org.scalatest.flatspec.AnyFlatSpec
+
+import ldbc.statement.functions.DateTime.*
+import ldbc.statement.Column
 
 class DateTimeTest extends AnyFlatSpec, DateTime:
 
@@ -46,7 +46,6 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DATE_SUB(LocalDate.of(2021, 1, 1), Interval.YEAR(1)).name == "DATE_SUB('2021-01-01', INTERVAL 1 YEAR)")
   }
 
-
   it should "Statement generated using the ADDTIME function matches the specified string." in {
     assert(ADDTIME(c3, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
     assert(ADDTIME(c4, LocalTime.of(1, 1, 1, 1)).name == "ADDTIME(local_time, '01:01:01.000000001')")
@@ -56,7 +55,13 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the CONVERT_TZ function matches the specified string." in {
     assert(CONVERT_TZ(c5, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
     assert(CONVERT_TZ(c6, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
-    assert(CONVERT_TZ(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ('2021-01-01T00:00', '+0:0', '+9:0')")
+    assert(
+      CONVERT_TZ(
+        LocalDateTime.of(2021, 1, 1, 0, 0),
+        LocalTime.of(0, 0),
+        LocalTime.of(9, 0)
+      ).name == "CONVERT_TZ('2021-01-01T00:00', '+0:0', '+9:0')"
+    )
   }
 
   it should "Statement generated using the CURDATE function matches the specified string." in {
@@ -76,7 +81,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the DATE_FORMAT function matches the specified string." in {
     assert(DATE_FORMAT(c5, "%Y-%m-%d").name == "DATE_FORMAT(local_date_time, '%Y-%m-%d')")
     assert(DATE_FORMAT(c6, "%Y-%m-%d").name == "DATE_FORMAT(local_date_time, '%Y-%m-%d')")
-    assert(DATE_FORMAT(LocalDateTime.of(2021, 1, 1, 0, 0), "%Y-%m-%d").name == "DATE_FORMAT('2021-01-01T00:00', '%Y-%m-%d')")
+    assert(
+      DATE_FORMAT(LocalDateTime.of(2021, 1, 1, 0, 0), "%Y-%m-%d").name == "DATE_FORMAT('2021-01-01T00:00', '%Y-%m-%d')"
+    )
   }
 
   it should "Statement generated using the DATEDIFF function matches the specified string." in {

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -105,3 +105,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DAYOFMONTH(c6).name == "DAYOFMONTH(local_date_time)")
     assert(DAYOFMONTH(LocalDate.of(2025, 1, 1)).name == "DAYOFMONTH('2025-01-01')")
   }
+
+  it should "Statement generated using the DAYOFWEEK function matches the specified string." in {
+    assert(DAYOFWEEK(c5).name == "DAYOFWEEK(local_date_time)")
+    assert(DAYOFWEEK(c6).name == "DAYOFWEEK(local_date_time)")
+    assert(DAYOFWEEK(LocalDate.of(2025, 1, 1)).name == "DAYOFWEEK('2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -111,3 +111,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(DAYOFWEEK(c6).name == "DAYOFWEEK(local_date_time)")
     assert(DAYOFWEEK(LocalDate.of(2025, 1, 1)).name == "DAYOFWEEK('2025-01-01')")
   }
+
+  it should "Statement generated using the DAYOFYEAR function matches the specified string." in {
+    assert(DAYOFYEAR(c5).name == "DAYOFYEAR(local_date_time)")
+    assert(DAYOFYEAR(c6).name == "DAYOFYEAR(local_date_time)")
+    assert(DAYOFYEAR(LocalDate.of(2025, 1, 1)).name == "DAYOFYEAR('2025-01-01')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -53,3 +53,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
   it should "Statement generated using the CURTIME function matches the specified string." in {
     assert(CURTIME.name == "CURTIME()")
   }
+
+  it should "Statement generated using the DATE function matches the specified string." in {
+    assert(DATE(c5).name == "DATE(local_date_time)")
+    assert(DATE(c6).name == "DATE(local_date_time)")
+    assert(DATE(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "DATE('2021-01-01T00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -194,3 +194,7 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MONTHNAME(c6).name == "MONTHNAME(local_date_time)")
     assert(MONTHNAME(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MONTHNAME('2021-01-01T00:00')")
   }
+
+  it should "Statement generated using the NOW function matches the specified string." in {
+    assert(NOW().name == "NOW()")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -182,3 +182,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(MINUTE(c6).name == "MINUTE(local_date_time)")
     assert(MINUTE(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MINUTE('2021-01-01 00:00')")
   }
+
+  it should "Statement generated using the MONTH function matches the specified string." in {
+    assert(MONTH(c5).name == "MONTH(local_date_time)")
+    assert(MONTH(c6).name == "MONTH(local_date_time)")
+    assert(MONTH(LocalDateTime.of(2021, 1, 1, 0, 0)).name == "MONTH('2021-01-01 00:00')")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -131,3 +131,9 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(FROM_DAYS(c8).name == "FROM_DAYS(days)")
     assert(FROM_DAYS(730669).name == "FROM_DAYS(730669)")
   }
+
+  it should "Statement generated using the FROM_UNIXTIME function matches the specified string." in {
+    assert(FROM_UNIXTIME(c7).name == "FROM_UNIXTIME(days)")
+    assert(FROM_UNIXTIME(c8).name == "FROM_UNIXTIME(days)")
+    assert(FROM_UNIXTIME(730669).name == "FROM_UNIXTIME(730669)")
+  }

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/functions/DateTimeTest.scala
@@ -40,9 +40,12 @@ class DateTimeTest extends AnyFlatSpec, DateTime:
     assert(ADDTIME(LocalTime.of(1, 1, 1), LocalTime.of(1, 1, 1, 1)).name == "ADDTIME('01:01:01', '01:01:01.000000001')")
   }
 
-
   it should "Statement generated using the CONVERT_TZ function matches the specified string." in {
     assert(CONVERT_TZ(c5, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
     assert(CONVERT_TZ(c6, LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ(local_date_time, '+0:0', '+9:0')")
     assert(CONVERT_TZ(LocalDateTime.of(2021, 1, 1, 0, 0), LocalTime.of(0, 0), LocalTime.of(9, 0)).name == "CONVERT_TZ('2021-01-01T00:00', '+0:0', '+9:0')")
+  }
+
+  it should "Statement generated using the CURDATE function matches the specified string." in {
+    assert(CURDATE.name == "CURDATE()")
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Added support for functions related to date types provided by MySQL officially.

https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/360

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
