### PR TITLE
Verification of direct decoding of Chunk

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/BitVectorSocket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/BitVectorSocket.scala
@@ -75,7 +75,7 @@ object BitVectorSocket:
         if carry.size < nBytes then
           withTimeout(socket.read(8192)).flatMap {
             case Some(bytes) => readChunkUntilN(nBytes, carry ++ bytes)
-            case None => F.raiseError(SQLTimeoutException("Timeout while reading from socket"))
+            case None        => F.raiseError(SQLTimeoutException("Timeout while reading from socket"))
           }
         else
           val (output, remainder) = carry.splitAt(nBytes)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/PacketSocket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/PacketSocket.scala
@@ -80,13 +80,13 @@ object PacketSocket:
         response = decoder(payload)
         _ <-
           debug(
-            s"Client ${AnsiColor.BLUE}←${AnsiColor.RESET} Server: ${AnsiColor.GREEN}$response${AnsiColor.RESET}"
+            s"Client ${ AnsiColor.BLUE }←${ AnsiColor.RESET } Server: ${ AnsiColor.GREEN }$response${ AnsiColor.RESET }"
           )
         _ <- sequenceIdRef.update(_ => ((header.toByteArray(3) + 1) % 256).toByte)
       yield response).onError {
         case t =>
           debug(
-            s"Client ${AnsiColor.BLUE}←${AnsiColor.RESET} Server: ${AnsiColor.RED}${t.getMessage}${AnsiColor.RESET}"
+            s"Client ${ AnsiColor.BLUE }←${ AnsiColor.RESET } Server: ${ AnsiColor.RED }${ t.getMessage }${ AnsiColor.RESET }"
           )
       }
 

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/Protocol.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/Protocol.scala
@@ -247,7 +247,9 @@ object Protocol:
 
       loop
 
-    override def readChunkUntilEOF[P <: ResponsePacket](decoder: fs2.Chunk[Byte] => P | EOFPacket | ERRPacket): F[Vector[P]] =
+    override def readChunkUntilEOF[P <: ResponsePacket](
+      decoder: fs2.Chunk[Byte] => P | EOFPacket | ERRPacket
+    ): F[Vector[P]] =
       val builder = Vector.newBuilder[P]
       def loop: F[Vector[P]] =
         socket.receiveChunk(decoder).flatMap {

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ResultSetRowPacket.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/packet/response/ResultSetRowPacket.scala
@@ -90,7 +90,7 @@ object ResultSetRowPacket:
 
   private def decodeChunkToString(chunk: fs2.Chunk[Byte], size: Int): (fs2.Chunk[Byte], Option[String]) =
     val (fieldSizeChunk, postFieldSizeChunk) = chunk.splitAt(size)
-    val fieldSizeNumBytes = fieldSizeChunk.toArray.foldLeft(0L)((acc, byte) => (acc << 8) | (byte & 0xFF))
+    val fieldSizeNumBytes = fieldSizeChunk.toArray.foldLeft(0L)((acc, byte) => (acc << 8) | (byte & 0xff))
     if fieldSizeNumBytes == NULL then (postFieldSizeChunk, None)
     else
       val (fieldChunk, postFieldChunk) = postFieldSizeChunk.splitAt(fieldSizeNumBytes.toInt)
@@ -98,8 +98,8 @@ object ResultSetRowPacket:
 
   private def decodeChunkResultSetRow(fieldLength: Int, columnLength: Int): fs2.Chunk[Byte] => ResultSetRowPacket =
     (chunk: fs2.Chunk[Byte]) =>
-      val buffer = new Array[Option[String]](columnLength)
-      var remainder = chunk
+      val buffer         = new Array[Option[String]](columnLength)
+      var remainder      = chunk
       var remainedLength = columnLength
       while remainedLength > 0 do
         val index = columnLength - remainedLength
@@ -110,7 +110,7 @@ object ResultSetRowPacket:
           remainder = postFieldChunk
         else
           val (lengthChunk, postLengthChunk) = remainder.splitAt(1)
-          val length = lengthChunk(0).toInt & 0xFF
+          val length                         = lengthChunk(0).toInt & 0xff
           remainder = postLengthChunk
           if length == NULL then buffer.update(index, None)
           else if length <= 251 then
@@ -131,7 +131,7 @@ object ResultSetRowPacket:
             remainder = postFieldSizeChunk
         end if
         remainedLength -= 1
-      
+
       ResultSetRowPacket(buffer)
 
   def decoder(
@@ -152,7 +152,7 @@ object ResultSetRowPacket:
   ): fs2.Chunk[Byte] => ResultSetRowPacket | EOFPacket | ERRPacket =
     (chunk: fs2.Chunk[Byte]) =>
       val (statusChunk, postLengthChunk) = chunk.splitAt(1)
-      val status = statusChunk(0).toInt & 0xFF
+      val status                         = statusChunk(0).toInt & 0xff
       status match
         case EOFPacket.STATUS => EOFPacket.decoder(capabilityFlags).decode(postLengthChunk.toBitVector).require.value
         case ERRPacket.STATUS => ERRPacket.decoder(capabilityFlags).decode(postLengthChunk.toBitVector).require.value

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -69,9 +69,13 @@ private[ldbc] case class StatementImpl[F[_]: Temporal: Exchange: Tracer](
                   result.size,
                   ColumnDefinitionPacket.decoder(protocol.initialPacket.capabilityFlags)
                 )
+              //resultSetRow <-
+              //  protocol.readUntilEOF[ResultSetRowPacket](
+              //    ResultSetRowPacket.decoder(protocol.initialPacket.capabilityFlags, columnDefinitions.length)
+              //  )
               resultSetRow <-
-                protocol.readUntilEOF[ResultSetRowPacket](
-                  ResultSetRowPacket.decoder(protocol.initialPacket.capabilityFlags, columnDefinitions.length)
+                protocol.readChunkUntilEOF[ResultSetRowPacket](
+                  ResultSetRowPacket.chunkDecoder(protocol.initialPacket.capabilityFlags, columnDefinitions.length)
                 )
               resultSet = ResultSetImpl(
                             columnDefinitions,

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -69,7 +69,7 @@ private[ldbc] case class StatementImpl[F[_]: Temporal: Exchange: Tracer](
                   result.size,
                   ColumnDefinitionPacket.decoder(protocol.initialPacket.capabilityFlags)
                 )
-              //resultSetRow <-
+              // resultSetRow <-
               //  protocol.readUntilEOF[ResultSetRowPacket](
               //    ResultSetRowPacket.decoder(protocol.initialPacket.capabilityFlags, columnDefinitions.length)
               //  )


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

The results when Chunk was used as is instead of using Scodec were as follows.

**Before**

![Select](https://github.com/user-attachments/assets/b01c6fcf-c240-4a81-abab-230de0c88bca)

**After**

![Select](https://github.com/user-attachments/assets/5c292b53-161f-4503-89a7-0cb283eb2fed)

As can be seen from the results, there is little difference between the patterns using Scodec and those using Chunk.

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/383

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
