### PR TITLE
Enclose columns in bag quotation marks

### DIFF
--- a/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
+++ b/module/ldbc-query-builder/src/test/scala/ldbc/query/builder/TableQueryTest.scala
@@ -23,21 +23,21 @@ class TableQueryTest extends AnyFlatSpec:
   private val joinQuery2 = TableQuery[JoinTest2]
 
   it should "The select query statement generated from Table is equal to the specified query statement." in {
-    assert(query.select(_.p1).statement === "SELECT test.p1 FROM test")
-    assert(query.select(_.p1).where(_.p1 > 1).statement === "SELECT test.p1 FROM test WHERE test.p1 > ?")
+    assert(query.select(_.p1).statement === "SELECT test.`p1` FROM test")
+    assert(query.select(_.p1).where(_.p1 > 1).statement === "SELECT test.`p1` FROM test WHERE test.`p1` > ?")
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt(test => Some(1).map(v => test.p1 >= v))
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     val opt: Option[Int] = None
     assert(
@@ -45,113 +45,113 @@ class TableQueryTest extends AnyFlatSpec:
         .select(_.p1)
         .whereOpt(test => opt.map(v => test.p1 orMore v))
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt(Some(1))((test, value) => test.p1 orMore value)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt[Int](None)((test, value) => test.p1 orMore value)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .and(_.p2 === "test", false)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .andOpt(Some("test"))((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .andOpt[String](None)((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt[Int](None)((test, value) => test.p1 orMore value)
         .andOpt[String](None)((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test"
+        .statement === "SELECT test.`p1` FROM test"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 || v.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? OR test.p2 = ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? OR test.`p2` = ?)"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 && v.p2 === "test")
         .or(_.p3 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? AND test.p2 = ?) OR test.p3 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? AND test.`p2` = ?) OR test.`p3` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 && v.p2 === "test")
         .or(_.p3 === "test", false)
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? AND test.p2 = ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? AND test.`p2` = ?)"
     )
-    assert(query.select(_.p1).groupBy(_.p1).statement === "SELECT test.p1 FROM test GROUP BY p1")
+    assert(query.select(_.p1).groupBy(_.p1).statement === "SELECT test.`p1` FROM test GROUP BY `p1`")
     assert(
       query
         .select(_.p1)
         .groupBy(_.p1)
         .having(_.p1 < 1)
-        .statement === "SELECT test.p1 FROM test GROUP BY p1 HAVING test.p1 < ?"
+        .statement === "SELECT test.`p1` FROM test GROUP BY `p1` HAVING test.`p1` < ?"
     )
-    assert(query.select(_.p1).orderBy(_.p1.desc).statement === "SELECT test.p1 FROM test ORDER BY test.p1 DESC")
-    assert(query.select(_.p1).limit(10).statement === "SELECT test.p1 FROM test LIMIT ?")
-    assert(query.select(_.p1).limit(10).offset(0).statement === "SELECT test.p1 FROM test LIMIT ? OFFSET ?")
+    assert(query.select(_.p1).orderBy(_.p1.desc).statement === "SELECT test.`p1` FROM test ORDER BY test.`p1` DESC")
+    assert(query.select(_.p1).limit(10).statement === "SELECT test.`p1` FROM test LIMIT ?")
+    assert(query.select(_.p1).limit(10).offset(0).statement === "SELECT test.`p1` FROM test LIMIT ? OFFSET ?")
     assert(
       query
         .select(_.p1)
         .where(_.p1 === query.select(_.p1).where(_.p1 > 1))
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 = (SELECT test.p1 FROM test WHERE test.p1 > ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` = (SELECT test.`p1` FROM test WHERE test.`p1` > ?)"
     )
     assert(
       query
         .select(_.p1)
         .where(v => (v.p1 >= query.select(_.p1).where(_.p1 > 1)) || (v.p2 === query.select(_.p2)))
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 >= (SELECT test.p1 FROM test WHERE test.p1 > ?) OR test.p2 = (SELECT test.p2 FROM test))"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` >= (SELECT test.`p1` FROM test WHERE test.`p1` > ?) OR test.`p2` = (SELECT test.`p2` FROM test))"
     )
     assert(
       query
         .join(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
         .leftJoin(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
         .rightJoin(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
@@ -160,7 +160,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -169,7 +169,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -178,7 +178,7 @@ class TableQueryTest extends AnyFlatSpec:
         .rightJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 RIGHT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` RIGHT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -187,7 +187,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -196,7 +196,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -205,7 +205,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -214,7 +214,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -223,25 +223,25 @@ class TableQueryTest extends AnyFlatSpec:
         .rightJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 RIGHT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` RIGHT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
-    assert(query.selectAll.statement === "SELECT test.p1, test.p2, test.p3 FROM test")
+    assert(query.selectAll.statement === "SELECT test.`p1`, test.`p2`, test.`p3` FROM test")
   }
 
   it should "The insert query statement generated from Table is equal to the specified query statement." in {
     assert(
-      query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+      query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")), (2L, "p2", None))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .values((1L, "p2", Some("p3")))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       query
@@ -250,10 +250,10 @@ class TableQueryTest extends AnyFlatSpec:
           (1L, "p2", Some("p3")),
           (2L, "p2", None)
         )
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
-      (query += Test(1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+      (query += Test(1L, "p2", Some("p3"))).statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       (query
@@ -263,61 +263,61 @@ class TableQueryTest extends AnyFlatSpec:
             Test(2L, "p2", None)
           )
         ))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query += Test(1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query += Test(1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .select(joinQuery.select(v => v.p1 *: v.p2 *: v.p3))
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT join_test.p1, join_test.p2, join_test.p3 FROM join_test"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT join_test.`p1`, join_test.`p2`, join_test.`p3` FROM join_test"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .select(joinQuery.select(v => v.p1 *: v.p2 *: v.p3).where(_.p1 > 1))
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT join_test.p1, join_test.p2, join_test.p3 FROM join_test WHERE join_test.p1 > ?"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT join_test.`p1`, join_test.`p2`, join_test.`p3` FROM join_test WHERE join_test.`p1` > ?"
     )
     assert(
       query
@@ -329,7 +329,7 @@ class TableQueryTest extends AnyFlatSpec:
             .select((t, j) => t.p1 *: t.p2 *: j.p3)
             .where((_, j) => j.p1 > 1)
         )
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT test.p1, test.p2, join_test.p3 FROM test JOIN join_test ON test.p1 = join_test.p1 WHERE join_test.p1 > ?"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT test.`p1`, test.`p2`, join_test.`p3` FROM test JOIN join_test ON test.`p1` = join_test.`p1` WHERE join_test.`p1` > ?"
     )
   }
 
@@ -339,7 +339,7 @@ class TableQueryTest extends AnyFlatSpec:
         .update(q => q.p1 *: q.p2 *: q.p3)(
           (1L, "p2", Some("p3"))
         )
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ?"
     )
     assert(
       query
@@ -347,25 +347,25 @@ class TableQueryTest extends AnyFlatSpec:
           (1L, "p2")
         )
         .where(_.p1 === 1L)
-        .statement === "UPDATE test SET p1 = ?, p2 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .where(_.p1 === 1L)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .whereOpt(Some(1L))((test, value) => test.p1 === value)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .whereOpt[Long](None)((test, value) => test.p1 === value)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ?"
     )
     assert(
       query
@@ -374,14 +374,14 @@ class TableQueryTest extends AnyFlatSpec:
         )
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -389,7 +389,7 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", false)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -397,7 +397,7 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", true)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -407,19 +407,19 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", false)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
   }
 
   it should "The delete query statement generated from Table is equal to the specified query statement." in {
     assert(query.delete.statement === "DELETE FROM test")
-    assert(query.delete.where(_.p1 === 1L).statement === "DELETE FROM test WHERE test.p1 = ?")
+    assert(query.delete.where(_.p1 === 1L).statement === "DELETE FROM test WHERE test.`p1` = ?")
     assert(
       query.delete
         .whereOpt(Some(1L))((test, value) => test.p1 === value)
-        .statement === "DELETE FROM test WHERE test.p1 = ?"
+        .statement === "DELETE FROM test WHERE test.`p1` = ?"
     )
     assert(query.delete.whereOpt[Long](None)((test, value) => test.p1 === value).statement === "DELETE FROM test")
     assert(query.delete.limit(1).statement === "DELETE FROM test LIMIT ?")
-    assert(query.delete.where(_.p1 === 1L).limit(1).statement === "DELETE FROM test WHERE test.p1 = ? LIMIT ?")
+    assert(query.delete.where(_.p1 === 1L).limit(1).statement === "DELETE FROM test WHERE test.`p1` = ? LIMIT ?")
   }

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/ColumnImpl.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/ColumnImpl.scala
@@ -25,7 +25,7 @@ private[ldbc] case class ColumnImpl[T](
     this.copy(alias = Some(name))
 
   override def statement: String =
-    dataType.fold(s"`$name`")(dataType => s"`$name` ${ dataType.queryString }") + attributes
+    dataType.fold(name)(dataType => s"$name ${ dataType.queryString }") + attributes
       .map(v => s" ${ v.queryString }")
       .mkString("")
   override def updateStatement:             String = s"$name = ?"

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -21,15 +21,15 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   export ldbc.statement.Column
 
   protected final def column[A](name: String)(using codec: Codec[A]): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, None, List.empty)
+    ColumnImpl[A](s"`$name`", Some(s"${ $name }.`$name`"), codec.asDecoder, codec.asEncoder, None, List.empty)
 
   protected final def column[A](name: String, dataType: DataType[A])(using codec: Codec[A]): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), List.empty)
+    ColumnImpl[A](s"`$name`", Some(s"${ $name }.`$name`"), codec.asDecoder, codec.asEncoder, Some(dataType), List.empty)
 
   protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using
     codec: Codec[A]
   ): Column[A] =
-    ColumnImpl[A](name, Some(s"${ $name }.$name"), codec.asDecoder, codec.asEncoder, Some(dataType), attributes.toList)
+    ColumnImpl[A](s"`$name`", Some(s"${ $name }.`$name`"), codec.asDecoder, codec.asEncoder, Some(dataType), attributes.toList)
 
   /**
    * Methods for setting key information for tables.

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -29,7 +29,14 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   protected final def column[A](name: String, dataType: DataType[A], attributes: Attribute[A]*)(using
     codec: Codec[A]
   ): Column[A] =
-    ColumnImpl[A](s"`$name`", Some(s"${ $name }.`$name`"), codec.asDecoder, codec.asEncoder, Some(dataType), attributes.toList)
+    ColumnImpl[A](
+      s"`$name`",
+      Some(s"${ $name }.`$name`"),
+      codec.asDecoder,
+      codec.asEncoder,
+      Some(dataType),
+      attributes.toList
+    )
 
   /**
    * Methods for setting key information for tables.

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/AliasTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/AliasTest.scala
@@ -34,10 +34,10 @@ class AliasTest extends AnyFlatSpec, Matchers:
     )
 
     assert(p1.queryString === "PRIMARY KEY")
-    assert(p2.queryString === "PRIMARY KEY (sub_id)")
-    assert(p3.queryString === "PRIMARY KEY (id, sub_id)")
-    assert(p4.queryString === "PRIMARY KEY (id, sub_id) USING BTREE")
-    assert(p5.queryString === "PRIMARY KEY (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1")
+    assert(p2.queryString === "PRIMARY KEY (`sub_id`)")
+    assert(p3.queryString === "PRIMARY KEY (`id`, `sub_id`)")
+    assert(p4.queryString === "PRIMARY KEY (`id`, `sub_id`) USING BTREE")
+    assert(p5.queryString === "PRIMARY KEY (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1")
   }
 
   it should "UNIQUE_KEY call succeeds" in {
@@ -56,12 +56,12 @@ class AliasTest extends AnyFlatSpec, Matchers:
     val p7 = UNIQUE_KEY(None, None, None, testTable.id *: testTable.subId)
 
     assert(p1.queryString === "UNIQUE KEY")
-    assert(p2.queryString === "UNIQUE KEY (sub_id)")
-    assert(p3.queryString === "UNIQUE KEY (id, sub_id)")
-    assert(p4.queryString === "UNIQUE KEY `index` (id, sub_id)")
-    assert(p5.queryString === "UNIQUE KEY `index` (id, sub_id) USING BTREE")
-    assert(p6.queryString === "UNIQUE KEY `index` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1")
-    assert(p7.queryString === "UNIQUE KEY (id, sub_id)")
+    assert(p2.queryString === "UNIQUE KEY (`sub_id`)")
+    assert(p3.queryString === "UNIQUE KEY (`id`, `sub_id`)")
+    assert(p4.queryString === "UNIQUE KEY `index` (`id`, `sub_id`)")
+    assert(p5.queryString === "UNIQUE KEY `index` (`id`, `sub_id`) USING BTREE")
+    assert(p6.queryString === "UNIQUE KEY `index` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1")
+    assert(p7.queryString === "UNIQUE KEY (`id`, `sub_id`)")
   }
 
   it should "INDEX_KEY call succeeds" in {
@@ -84,12 +84,12 @@ class AliasTest extends AnyFlatSpec, Matchers:
       testTable.id *: testTable.subId
     )
 
-    assert(p1.queryString === "INDEX (sub_id)")
-    assert(p2.queryString === "INDEX (id, sub_id)")
-    assert(p3.queryString === "INDEX (id, sub_id)")
-    assert(p4.queryString === "INDEX `index` (id, sub_id)")
-    assert(p5.queryString === "INDEX `index` (id, sub_id) USING BTREE")
-    assert(p6.queryString === "INDEX `index` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1")
+    assert(p1.queryString === "INDEX (`sub_id`)")
+    assert(p2.queryString === "INDEX (`id`, `sub_id`)")
+    assert(p3.queryString === "INDEX (`id`, `sub_id`)")
+    assert(p4.queryString === "INDEX `index` (`id`, `sub_id`)")
+    assert(p5.queryString === "INDEX `index` (`id`, `sub_id`) USING BTREE")
+    assert(p6.queryString === "INDEX `index` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1")
   }
 
   it should "FOREIGN_KEY call succeeds" in {
@@ -110,6 +110,6 @@ class AliasTest extends AnyFlatSpec, Matchers:
       REFERENCE(subTestTable, subTestTable.id *: subTestTable.status)
     )
 
-    assert(p1.queryString === "FOREIGN KEY (sub_id) REFERENCES sub_test (id)")
-    assert(p2.queryString === "FOREIGN KEY (sub_id, status) REFERENCES sub_test (id, status)")
+    assert(p1.queryString === "FOREIGN KEY (`sub_id`) REFERENCES sub_test (`id`)")
+    assert(p2.queryString === "FOREIGN KEY (`sub_id`, `status`) REFERENCES sub_test (`id`, `status`)")
   }

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/ColumnImplTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/ColumnImplTest.scala
@@ -21,7 +21,7 @@ class ColumnImplTest extends AnyFlatSpec:
     decoder: Decoder[A],
     encoder: Encoder[A]
   ): Column[A] =
-    ColumnImpl[A](name, None, decoder, encoder, Some(dataType), attributes.toList)
+    ColumnImpl[A](s"`$name`", None, decoder, encoder, Some(dataType), attributes.toList)
 
   it should "The query string of the Column model generated with only label and DataType matches the specified string." in {
     assert(column[Long]("id", BIGINT).statement === "`id` BIGINT NOT NULL")

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/KeyTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/KeyTest.scala
@@ -21,17 +21,17 @@ class KeyTest extends AnyFlatSpec:
 
   it should "[1] The query string of the generated IndexKey model matches the specified string." in {
     val key = IndexKey(None, None, testTable.id *: testTable.subId, None)
-    assert(key.queryString === "INDEX (id, sub_id)")
+    assert(key.queryString === "INDEX (`id`, `sub_id`)")
   }
 
   it should "[2] The query string of the generated IndexKey model matches the specified string." in {
     val key = IndexKey(Some("key_id"), None, testTable.id *: testTable.subId, None)
-    assert(key.queryString === "INDEX `key_id` (id, sub_id)")
+    assert(key.queryString === "INDEX `key_id` (`id`, `sub_id`)")
   }
 
   it should "[3] The query string of the generated IndexKey model matches the specified string." in {
     val key = IndexKey(Some("key_id"), Some(Index.Type.BTREE), testTable.id *: testTable.subId, None)
-    assert(key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE")
+    assert(key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE")
   }
 
   it should "[4] The query string of the generated IndexKey model matches the specified string." in {
@@ -41,7 +41,7 @@ class KeyTest extends AnyFlatSpec:
       testTable.id *: testTable.subId,
       Some(Index.IndexOption(Some(1), None, None, None, None, None))
     )
-    assert(key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1")
+    assert(key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1")
   }
 
   it should "[5] The query string of the generated IndexKey model matches the specified string." in {
@@ -51,7 +51,7 @@ class KeyTest extends AnyFlatSpec:
       testTable.id *: testTable.subId,
       Some(Index.IndexOption(Some(1), Some(Index.Type.BTREE), None, None, None, None))
     )
-    assert(key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE")
+    assert(key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE")
   }
 
   it should "[6] The query string of the generated IndexKey model matches the specified string." in {
@@ -62,7 +62,7 @@ class KeyTest extends AnyFlatSpec:
       Some(Index.IndexOption(Some(1), Some(Index.Type.BTREE), Some("parser"), None, None, None))
     )
     assert(
-      key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser"
+      key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser"
     )
   }
 
@@ -74,7 +74,7 @@ class KeyTest extends AnyFlatSpec:
       Some(Index.IndexOption(Some(1), Some(Index.Type.BTREE), Some("parser"), Some("comment"), None, None))
     )
     assert(
-      key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser COMMENT 'comment'"
+      key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser COMMENT 'comment'"
     )
   }
 
@@ -86,6 +86,6 @@ class KeyTest extends AnyFlatSpec:
       Some(Index.IndexOption(Some(1), Some(Index.Type.BTREE), Some("parser"), Some("comment"), Some("InnoDB"), None))
     )
     assert(
-      key.queryString === "INDEX `key_id` (id, sub_id) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser COMMENT 'comment' ENGINE_ATTRIBUTE = 'InnoDB'"
+      key.queryString === "INDEX `key_id` (`id`, `sub_id`) USING BTREE KEY_BLOCK_SIZE = 1 USING BTREE WITH PARSER parser COMMENT 'comment' ENGINE_ATTRIBUTE = 'InnoDB'"
     )
   }

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableQueryTest.scala
@@ -42,21 +42,21 @@ class TableQueryTest extends AnyFlatSpec:
   private val joinQuery2 = TableQuery[JoinTest2Table]
 
   it should "The select query statement generated from Table is equal to the specified query statement." in {
-    assert(query.select(_.p1).statement === "SELECT test.p1 FROM test")
-    assert(query.select(_.p1).where(_.p1 > 1).statement === "SELECT test.p1 FROM test WHERE test.p1 > ?")
+    assert(query.select(_.p1).statement === "SELECT test.`p1` FROM test")
+    assert(query.select(_.p1).where(_.p1 > 1).statement === "SELECT test.`p1` FROM test WHERE test.`p1` > ?")
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt(test => Some(1).map(v => test.p1 >= v))
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     val opt: Option[Int] = None
     assert(
@@ -64,113 +64,113 @@ class TableQueryTest extends AnyFlatSpec:
         .select(_.p1)
         .whereOpt(test => opt.map(v => test.p1 orMore v))
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt(Some(1))((test, value) => test.p1 orMore value)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt[Int](None)((test, value) => test.p1 orMore value)
         .and(_.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .and(_.p2 === "test", false)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .andOpt(Some("test"))((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ? AND test.p2 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ? AND test.`p2` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(_.p1 >= 1)
         .andOpt[String](None)((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 >= ?"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` >= ?"
     )
     assert(
       query
         .select(_.p1)
         .whereOpt[Int](None)((test, value) => test.p1 orMore value)
         .andOpt[String](None)((test, value) => test.p2 _equals value)
-        .statement === "SELECT test.p1 FROM test"
+        .statement === "SELECT test.`p1` FROM test"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 || v.p2 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? OR test.p2 = ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? OR test.`p2` = ?)"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 && v.p2 === "test")
         .or(_.p3 === "test")
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? AND test.p2 = ?) OR test.p3 = ?"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? AND test.`p2` = ?) OR test.`p3` = ?"
     )
     assert(
       query
         .select(_.p1)
         .where(v => v.p1 > 1 && v.p2 === "test")
         .or(_.p3 === "test", false)
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 > ? AND test.p2 = ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` > ? AND test.`p2` = ?)"
     )
-    assert(query.select(_.p1).groupBy(_.p1).statement === "SELECT test.p1 FROM test GROUP BY p1")
+    assert(query.select(_.p1).groupBy(_.p1).statement === "SELECT test.`p1` FROM test GROUP BY `p1`")
     assert(
       query
         .select(_.p1)
         .groupBy(_.p1)
         .having(_.p1 < 1)
-        .statement === "SELECT test.p1 FROM test GROUP BY p1 HAVING test.p1 < ?"
+        .statement === "SELECT test.`p1` FROM test GROUP BY `p1` HAVING test.`p1` < ?"
     )
-    assert(query.select(_.p1).orderBy(_.p1.desc).statement === "SELECT test.p1 FROM test ORDER BY test.p1 DESC")
-    assert(query.select(_.p1).limit(10).statement === "SELECT test.p1 FROM test LIMIT ?")
-    assert(query.select(_.p1).limit(10).offset(0).statement === "SELECT test.p1 FROM test LIMIT ? OFFSET ?")
+    assert(query.select(_.p1).orderBy(_.p1.desc).statement === "SELECT test.`p1` FROM test ORDER BY test.`p1` DESC")
+    assert(query.select(_.p1).limit(10).statement === "SELECT test.`p1` FROM test LIMIT ?")
+    assert(query.select(_.p1).limit(10).offset(0).statement === "SELECT test.`p1` FROM test LIMIT ? OFFSET ?")
     assert(
       query
         .select(_.p1)
         .where(_.p1 === query.select(_.p1).where(_.p1 > 1))
-        .statement === "SELECT test.p1 FROM test WHERE test.p1 = (SELECT test.p1 FROM test WHERE test.p1 > ?)"
+        .statement === "SELECT test.`p1` FROM test WHERE test.`p1` = (SELECT test.`p1` FROM test WHERE test.`p1` > ?)"
     )
     assert(
       query
         .select(_.p1)
         .where(v => (v.p1 >= query.select(_.p1).where(_.p1 > 1)) || (v.p2 === query.select(_.p2)))
-        .statement === "SELECT test.p1 FROM test WHERE (test.p1 >= (SELECT test.p1 FROM test WHERE test.p1 > ?) OR test.p2 = (SELECT test.p2 FROM test))"
+        .statement === "SELECT test.`p1` FROM test WHERE (test.`p1` >= (SELECT test.`p1` FROM test WHERE test.`p1` > ?) OR test.`p2` = (SELECT test.`p2` FROM test))"
     )
     assert(
       query
         .join(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
         .leftJoin(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
         .rightJoin(joinQuery)
         .on((test, joinTest) => test.p1 === joinTest.p1)
         .select((test, joinTest) => test.p2 *: joinTest.p2)
-        .statement === "SELECT test.p2, join_test.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1`"
     )
     assert(
       query
@@ -179,7 +179,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -188,7 +188,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -197,7 +197,7 @@ class TableQueryTest extends AnyFlatSpec:
         .rightJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test JOIN join_test ON test.p1 = join_test.p1 RIGHT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test JOIN join_test ON test.`p1` = join_test.`p1` RIGHT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -206,7 +206,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -215,7 +215,7 @@ class TableQueryTest extends AnyFlatSpec:
         .join(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1 JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1` JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -224,7 +224,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test RIGHT JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test RIGHT JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -233,7 +233,7 @@ class TableQueryTest extends AnyFlatSpec:
         .leftJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 LEFT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` LEFT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
     assert(
       query
@@ -242,25 +242,25 @@ class TableQueryTest extends AnyFlatSpec:
         .rightJoin(joinQuery2)
         .on((_, joinTest, joinTest2) => joinTest.p1 === joinTest2.p1)
         .select((test, joinTest, joinTest2) => test.p2 *: joinTest.p2 *: joinTest2.p2)
-        .statement === "SELECT test.p2, join_test.p2, join_test2.p2 FROM test LEFT JOIN join_test ON test.p1 = join_test.p1 RIGHT JOIN join_test2 ON join_test.p1 = join_test2.p1"
+        .statement === "SELECT test.`p2`, join_test.`p2`, join_test2.`p2` FROM test LEFT JOIN join_test ON test.`p1` = join_test.`p1` RIGHT JOIN join_test2 ON join_test.`p1` = join_test2.`p1`"
     )
-    assert(query.selectAll.statement === "SELECT test.p1, test.p2, test.p3 FROM test")
+    assert(query.selectAll.statement === "SELECT test.`p1`, test.`p2`, test.`p3` FROM test")
   }
 
   it should "The insert query statement generated from Table is equal to the specified query statement." in {
     assert(
-      query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+      query.insert((1L, "p2", Some("p3"))).statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")), (2L, "p2", None))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .values((1L, "p2", Some("p3")))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       query
@@ -269,10 +269,10 @@ class TableQueryTest extends AnyFlatSpec:
           (1L, "p2", Some("p3")),
           (2L, "p2", None)
         )
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
-      (query += Test(1L, "p2", Some("p3"))).statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?)"
+      (query += Test(1L, "p2", Some("p3"))).statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?)"
     )
     assert(
       (query
@@ -282,61 +282,61 @@ class TableQueryTest extends AnyFlatSpec:
             Test(2L, "p2", None)
           )
         ))
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")), (2L, "p2", None))
         .onDuplicateKeyUpdate(t => t.p1 *: t.p2 *: t.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insert((1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query += Test(1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query += Test(1L, "p2", Some("p3")))
         .onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(_.p1)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`)"
     )
     assert(
       (query ++= NonEmptyList.of(
         Test(1L, "p2", Some("p3")),
         Test(2L, "p2", None)
       )).onDuplicateKeyUpdate(v => v.p1 *: v.p2 *: v.p3)
-        .statement === "INSERT INTO test (p1, p2, p3) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE p1 = VALUES(test.p1), p2 = VALUES(test.p2), p3 = VALUES(test.p3)"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) VALUES (?,?,?),(?,?,?) ON DUPLICATE KEY UPDATE `p1` = VALUES(test.`p1`), `p2` = VALUES(test.`p2`), `p3` = VALUES(test.`p3`)"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .select(joinQuery.select(v => v.p1 *: v.p2 *: v.p3))
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT join_test.p1, join_test.p2, join_test.p3 FROM join_test"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT join_test.`p1`, join_test.`p2`, join_test.`p3` FROM join_test"
     )
     assert(
       query
         .insertInto(v => v.p1 *: v.p2 *: v.p3)
         .select(joinQuery.select(v => v.p1 *: v.p2 *: v.p3).where(_.p1 > 1))
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT join_test.p1, join_test.p2, join_test.p3 FROM join_test WHERE join_test.p1 > ?"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT join_test.`p1`, join_test.`p2`, join_test.`p3` FROM join_test WHERE join_test.`p1` > ?"
     )
     assert(
       query
@@ -348,7 +348,7 @@ class TableQueryTest extends AnyFlatSpec:
             .select((t, j) => t.p1 *: t.p2 *: j.p3)
             .where((_, j) => j.p1 > 1)
         )
-        .statement === "INSERT INTO test (p1, p2, p3) SELECT test.p1, test.p2, join_test.p3 FROM test JOIN join_test ON test.p1 = join_test.p1 WHERE join_test.p1 > ?"
+        .statement === "INSERT INTO test (`p1`, `p2`, `p3`) SELECT test.`p1`, test.`p2`, join_test.`p3` FROM test JOIN join_test ON test.`p1` = join_test.`p1` WHERE join_test.`p1` > ?"
     )
   }
 
@@ -358,7 +358,7 @@ class TableQueryTest extends AnyFlatSpec:
         .update(q => q.p1 *: q.p2 *: q.p3)(
           (1L, "p2", Some("p3"))
         )
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ?"
     )
     assert(
       query
@@ -366,31 +366,31 @@ class TableQueryTest extends AnyFlatSpec:
           (1L, "p2")
         )
         .where(_.p1 === 1L)
-        .statement === "UPDATE test SET p1 = ?, p2 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .where(_.p1 === 1L)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .whereOpt(test => Some(1L).map(v => test.p1 _equals v))
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .whereOpt(Some(1L))((test, value) => test.p1 === value)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .whereOpt[Long](None)((test, value) => test.p1 === value)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ?"
     )
     assert(
       query
@@ -399,14 +399,14 @@ class TableQueryTest extends AnyFlatSpec:
         )
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
         .update(Test(1L, "p2", Some("p3")))
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -414,7 +414,7 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", false)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -422,7 +422,7 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", true)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p2 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p2` = ? WHERE test.`p1` = ? LIMIT ?"
     )
     assert(
       query
@@ -432,24 +432,24 @@ class TableQueryTest extends AnyFlatSpec:
         .set(_.p2, "p2", false)
         .where(_.p1 === 1L)
         .limit(1)
-        .statement === "UPDATE test SET p1 = ?, p3 = ? WHERE test.p1 = ? LIMIT ?"
+        .statement === "UPDATE test SET `p1` = ?, `p3` = ? WHERE test.`p1` = ? LIMIT ?"
     )
   }
 
   it should "The delete query statement generated from Table is equal to the specified query statement." in {
     assert(query.delete.statement === "DELETE FROM test")
-    assert(query.delete.where(_.p1 === 1L).statement === "DELETE FROM test WHERE test.p1 = ?")
+    assert(query.delete.where(_.p1 === 1L).statement === "DELETE FROM test WHERE test.`p1` = ?")
     assert(
       query.delete
         .whereOpt(test => Some(1L).map(v => test.p1 _equals v))
-        .statement === "DELETE FROM test WHERE test.p1 = ?"
+        .statement === "DELETE FROM test WHERE test.`p1` = ?"
     )
     assert(
       query.delete
         .whereOpt(Some(1L))((test, value) => test.p1 === value)
-        .statement === "DELETE FROM test WHERE test.p1 = ?"
+        .statement === "DELETE FROM test WHERE test.`p1` = ?"
     )
     assert(query.delete.whereOpt[Long](None)((test, value) => test.p1 === value).statement === "DELETE FROM test")
     assert(query.delete.limit(1).statement === "DELETE FROM test LIMIT ?")
-    assert(query.delete.where(_.p1 === 1L).limit(1).statement === "DELETE FROM test WHERE test.p1 = ? LIMIT ?")
+    assert(query.delete.where(_.p1 === 1L).limit(1).statement === "DELETE FROM test WHERE test.`p1` = ? LIMIT ?")
   }

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -780,7 +780,7 @@ object Column extends TwiddleSyntax[Column]:
     Impl[A](name)
 
   def apply[A](name: String, alias: String)(using Decoder[A], Encoder[A]): Column[A] =
-    Impl[A](name, s"$alias.$name")
+    Impl[A](name, s"$alias.`$name`")
 
   private[ldbc] case class Impl[A](
     name:    String,

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/Column.scala
@@ -798,10 +798,10 @@ object Column extends TwiddleSyntax[Column]:
 
   object Impl:
     def apply[A](name: String)(using decoder: Decoder[A], encoder: Encoder[A]): Column[A] =
-      Impl[A](name, None, decoder, encoder)
+      Impl[A](s"`$name`", None, decoder, encoder)
 
     def apply[A](name: String, alias: String)(using decoder: Decoder[A], encoder: Encoder[A]): Column[A] =
-      Impl[A](name, Some(alias), decoder, encoder)
+      Impl[A](s"`$name`", Some(alias), decoder, encoder)
 
   private[ldbc] case class Opt[A](
     name:     String,

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/ColumnTest.scala
@@ -27,191 +27,191 @@ class ColumnTest extends AnyFlatSpec:
   private val token2 = Column.Impl[Option[Token]]("token")
 
   it should "The string of the expression syntax that constructs the match with the specified value matches the specified string." in {
-    assert((id1 === 1L).statement === "id = ?")
-    assert((id1 === 1L).NOT.statement === "NOT id = ?")
-    assert((id2 === 1L).statement === "id = ?")
-    assert((id2 === 1L).NOT.statement === "NOT id = ?")
+    assert((id1 === 1L).statement === "`id` = ?")
+    assert((id1 === 1L).NOT.statement === "NOT `id` = ?")
+    assert((id2 === 1L).statement === "`id` = ?")
+    assert((id2 === 1L).NOT.statement === "NOT `id` = ?")
   }
 
   it should "The string constructed by the expression syntax that determines if it is greater than or equal to the specified value matches the specified string." in {
-    assert((id1 >= 1L).statement === "id >= ?")
-    assert((id1 >= 1L).NOT.statement === "NOT id >= ?")
-    assert((id2 >= 1L).statement === "id >= ?")
-    assert((id2 >= 1L).NOT.statement === "NOT id >= ?")
+    assert((id1 >= 1L).statement === "`id` >= ?")
+    assert((id1 >= 1L).NOT.statement === "NOT `id` >= ?")
+    assert((id2 >= 1L).statement === "`id` >= ?")
+    assert((id2 >= 1L).NOT.statement === "NOT `id` >= ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether the specified value is exceeded matches the specified string." in {
-    assert((id1 > 1L).statement === "id > ?")
-    assert((id1 > 1L).NOT.statement === "NOT id > ?")
-    assert((id2 > 1L).statement === "id > ?")
-    assert((id2 > 1L).NOT.statement === "NOT id > ?")
+    assert((id1 > 1L).statement === "`id` > ?")
+    assert((id1 > 1L).NOT.statement === "NOT `id` > ?")
+    assert((id2 > 1L).statement === "`id` > ?")
+    assert((id2 > 1L).NOT.statement === "NOT `id` > ?")
   }
 
   it should "The string constructed by the expression syntax that determines if it is less than or equal to the specified value matches the specified string." in {
-    assert((id1 <= 1L).statement === "id <= ?")
-    assert((id1 <= 1L).NOT.statement === "NOT id <= ?")
-    assert((id2 <= 1L).statement === "id <= ?")
-    assert((id2 <= 1L).NOT.statement === "NOT id <= ?")
+    assert((id1 <= 1L).statement === "`id` <= ?")
+    assert((id1 <= 1L).NOT.statement === "NOT `id` <= ?")
+    assert((id2 <= 1L).statement === "`id` <= ?")
+    assert((id2 <= 1L).NOT.statement === "NOT `id` <= ?")
   }
 
   it should "The string constructed by the expression syntax that determines if it is less than the specified value matches the specified string." in {
-    assert((id1 < 1L).statement === "id < ?")
-    assert((id1 < 1L).NOT.statement === "NOT id < ?")
-    assert((id2 < 1L).statement === "id < ?")
-    assert((id2 < 1L).NOT.statement === "NOT id < ?")
+    assert((id1 < 1L).statement === "`id` < ?")
+    assert((id1 < 1L).NOT.statement === "NOT `id` < ?")
+    assert((id2 < 1L).statement === "`id` < ?")
+    assert((id2 < 1L).NOT.statement === "NOT `id` < ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether the specified value match or not matches the specified string." in {
-    assert((id1 <> 1L).statement === "id <> ?")
-    assert((id1 <> 1L).NOT.statement === "NOT id <> ?")
-    assert((id1 !== 1L).statement === "id != ?")
-    assert((id1 !== 1L).NOT.statement === "NOT id != ?")
-    assert((id2 <> 1L).statement === "id <> ?")
-    assert((id2 <> 1L).NOT.statement === "NOT id <> ?")
-    assert((id2 !== 1L).statement === "id != ?")
-    assert((id2 !== 1L).NOT.statement === "NOT id != ?")
+    assert((id1 <> 1L).statement === "`id` <> ?")
+    assert((id1 <> 1L).NOT.statement === "NOT `id` <> ?")
+    assert((id1 !== 1L).statement === "`id` != ?")
+    assert((id1 !== 1L).NOT.statement === "NOT `id` != ?")
+    assert((id2 <> 1L).statement === "`id` <> ?")
+    assert((id2 <> 1L).NOT.statement === "NOT `id` <> ?")
+    assert((id2 !== 1L).statement === "`id` != ?")
+    assert((id2 !== 1L).NOT.statement === "NOT `id` != ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether it is a Boolean value that can be TRUE, FALSE, or UNKNOWN matches the specified string." in {
-    assert((id1 IS "TRUE").statement === "id IS TRUE")
-    assert((id1 IS "FALSE").NOT.statement === "id IS NOT FALSE")
-    assert((id2 IS "TRUE").statement === "id IS TRUE")
-    assert((id2 IS "NULL").statement === "id IS NULL")
-    assert((id2 IS "UNKNOWN").NOT.statement === "id IS NOT UNKNOWN")
+    assert((id1 IS "TRUE").statement === "`id` IS TRUE")
+    assert((id1 IS "FALSE").NOT.statement === "`id` IS NOT FALSE")
+    assert((id2 IS "TRUE").statement === "`id` IS TRUE")
+    assert((id2 IS "NULL").statement === "`id` IS NULL")
+    assert((id2 IS "UNKNOWN").NOT.statement === "`id` IS NOT UNKNOWN")
   }
 
   it should "NULL - The string constructed by the expression syntax to determine safe equivalence matches the specified string." in {
-    assert((id1 <=> 1L).statement === "id <=> ?")
-    assert((id1 <=> 1L).NOT.statement === "NOT id <=> ?")
-    assert((id2 <=> 1L).statement === "id <=> ?")
-    assert((id2 <=> 1L).NOT.statement === "NOT id <=> ?")
+    assert((id1 <=> 1L).statement === "`id` <=> ?")
+    assert((id1 <=> 1L).NOT.statement === "NOT `id` <=> ?")
+    assert((id2 <=> 1L).statement === "`id` <=> ?")
+    assert((id2 <=> 1L).NOT.statement === "NOT `id` <=> ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether it contains at least one of the specified values matches the specified string." in {
-    assert((id1 IN (1L, 2L)).statement === "id IN (?, ?)")
-    assert((id1 IN (1L, 2L)).NOT.statement === "id NOT IN (?, ?)")
-    assert((id2 IN (1L, 2L)).statement === "id IN (?, ?)")
-    assert((id2 IN (1L, 2L, 3L)).NOT.statement === "id NOT IN (?, ?, ?)")
+    assert((id1 IN (1L, 2L)).statement === "`id` IN (?, ?)")
+    assert((id1 IN (1L, 2L)).NOT.statement === "`id` NOT IN (?, ?)")
+    assert((id2 IN (1L, 2L)).statement === "`id` IN (?, ?)")
+    assert((id2 IN (1L, 2L, 3L)).NOT.statement === "`id` NOT IN (?, ?, ?)")
   }
 
   it should "The string constructed by the expression syntax that determines whether the value falls within the specified range matches the specified string." in {
-    assert((id1 BETWEEN (1L, 10L)).statement === "id BETWEEN ? AND ?")
-    assert((id1 BETWEEN (1L, 10L)).NOT.statement === "id NOT BETWEEN ? AND ?")
-    assert((id2 BETWEEN (1L, 10L)).statement === "id BETWEEN ? AND ?")
-    assert((id2 BETWEEN (1L, 10L)).NOT.statement === "id NOT BETWEEN ? AND ?")
+    assert((id1 BETWEEN (1L, 10L)).statement === "`id` BETWEEN ? AND ?")
+    assert((id1 BETWEEN (1L, 10L)).NOT.statement === "`id` NOT BETWEEN ? AND ?")
+    assert((id2 BETWEEN (1L, 10L)).statement === "`id` BETWEEN ? AND ?")
+    assert((id2 BETWEEN (1L, 10L)).NOT.statement === "`id` NOT BETWEEN ? AND ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether it contains a matching string matches the specified string." in {
-    assert((name1 LIKE "ldbc").statement === "name LIKE ?")
-    assert((name1 LIKE "ldbc").NOT.statement === "NOT name LIKE ?")
-    assert((name2 LIKE "ldbc").statement === "name LIKE ?")
-    assert((name2 LIKE "ldbc").NOT.statement === "NOT name LIKE ?")
-    assert((name1 LIKE_ESCAPE ("T%", "$")).statement === "name LIKE ? ESCAPE ?")
-    assert((name1 LIKE_ESCAPE ("T%", "$")).NOT.statement === "NOT name LIKE ? ESCAPE ?")
-    assert((name2 LIKE_ESCAPE ("T%", "$")).statement === "name LIKE ? ESCAPE ?")
-    assert((name2 LIKE_ESCAPE ("T%", "$")).NOT.statement === "NOT name LIKE ? ESCAPE ?")
+    assert((name1 LIKE "ldbc").statement === "`name` LIKE ?")
+    assert((name1 LIKE "ldbc").NOT.statement === "NOT `name` LIKE ?")
+    assert((name2 LIKE "ldbc").statement === "`name` LIKE ?")
+    assert((name2 LIKE "ldbc").NOT.statement === "NOT `name` LIKE ?")
+    assert((name1 LIKE_ESCAPE ("T%", "$")).statement === "`name` LIKE ? ESCAPE ?")
+    assert((name1 LIKE_ESCAPE ("T%", "$")).NOT.statement === "NOT `name` LIKE ? ESCAPE ?")
+    assert((name2 LIKE_ESCAPE ("T%", "$")).statement === "`name` LIKE ? ESCAPE ?")
+    assert((name2 LIKE_ESCAPE ("T%", "$")).NOT.statement === "NOT `name` LIKE ? ESCAPE ?")
   }
 
   it should "The string constructed by the expression syntax that determines whether it matches the regular expression pattern matches the specified string." in {
-    assert((name1 REGEXP "^[A-D]'").statement === "name REGEXP ?")
-    assert((name1 REGEXP "^[A-D]'").NOT.statement === "NOT name REGEXP ?")
-    assert((name2 REGEXP "^[A-D]'").statement === "name REGEXP ?")
-    assert((name2 REGEXP "^[A-D]'").NOT.statement === "NOT name REGEXP ?")
+    assert((name1 REGEXP "^[A-D]'").statement === "`name` REGEXP ?")
+    assert((name1 REGEXP "^[A-D]'").NOT.statement === "NOT `name` REGEXP ?")
+    assert((name2 REGEXP "^[A-D]'").statement === "`name` REGEXP ?")
+    assert((name2 REGEXP "^[A-D]'").NOT.statement === "NOT `name` REGEXP ?")
   }
 
   it should "The string constructed by the expression syntax that performs the integer division operation to determine if it matches matches the specified string." in {
-    assert((id1 DIV (5L, 10L)).statement === "id DIV ? = ?")
-    assert((id1 DIV (5L, 10L)).NOT.statement === "NOT id DIV ? = ?")
-    assert((id2 DIV (5L, 10L)).statement === "id DIV ? = ?")
-    assert((id2 DIV (5L, 10L)).NOT.statement === "NOT id DIV ? = ?")
+    assert((id1 DIV (5L, 10L)).statement === "`id` DIV ? = ?")
+    assert((id1 DIV (5L, 10L)).NOT.statement === "NOT `id` DIV ? = ?")
+    assert((id2 DIV (5L, 10L)).statement === "`id` DIV ? = ?")
+    assert((id2 DIV (5L, 10L)).NOT.statement === "NOT `id` DIV ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the operation to find the remainder and determines whether it matches matches the specified string." in {
-    assert((id1 MOD (5L, 0L)).statement === "id MOD ? = ?")
-    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id1 % (5L, 0L)).statement === "id % ? = ?")
-    assert((id1 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
-    assert((id2 MOD (5L, 0L)).statement === "id MOD ? = ?")
-    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id2 % (5L, 0L)).statement === "id % ? = ?")
-    assert((id2 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
+    assert((id1 MOD (5L, 0L)).statement === "`id` MOD ? = ?")
+    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT `id` MOD ? = ?")
+    assert((id1 % (5L, 0L)).statement === "`id` % ? = ?")
+    assert((id1 % (5L, 0L)).NOT.statement === "NOT `id` % ? = ?")
+    assert((id2 MOD (5L, 0L)).statement === "`id` MOD ? = ?")
+    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT `id` MOD ? = ?")
+    assert((id2 % (5L, 0L)).statement === "`id` % ? = ?")
+    assert((id2 % (5L, 0L)).NOT.statement === "NOT `id` % ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the bit XOR operation to determine if it matches matches the specified string." in {
-    assert((id1 MOD (5L, 0L)).statement === "id MOD ? = ?")
-    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id1 % (5L, 0L)).statement === "id % ? = ?")
-    assert((id1 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
-    assert((id2 MOD (5L, 0L)).statement === "id MOD ? = ?")
-    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT id MOD ? = ?")
-    assert((id2 % (5L, 0L)).statement === "id % ? = ?")
-    assert((id2 % (5L, 0L)).NOT.statement === "NOT id % ? = ?")
+    assert((id1 MOD (5L, 0L)).statement === "`id` MOD ? = ?")
+    assert((id1 MOD (5L, 0L)).NOT.statement === "NOT `id` MOD ? = ?")
+    assert((id1 % (5L, 0L)).statement === "`id` % ? = ?")
+    assert((id1 % (5L, 0L)).NOT.statement === "NOT `id` % ? = ?")
+    assert((id2 MOD (5L, 0L)).statement === "`id` MOD ? = ?")
+    assert((id2 MOD (5L, 0L)).NOT.statement === "NOT `id` MOD ? = ?")
+    assert((id2 % (5L, 0L)).statement === "`id` % ? = ?")
+    assert((id2 % (5L, 0L)).NOT.statement === "NOT `id` % ? = ?")
   }
 
   it should "The string constructed by the expression syntax that performs the left shift operation to determine if it matches matches the specified string." in {
-    assert((id1 ^ 1L).statement === "id ^ ?")
-    assert((id1 ^ 1L).NOT.statement === "NOT id ^ ?")
-    assert((id2 ^ 1L).statement === "id ^ ?")
-    assert((id2 ^ 1L).NOT.statement === "NOT id ^ ?")
+    assert((id1 ^ 1L).statement === "`id` ^ ?")
+    assert((id1 ^ 1L).NOT.statement === "NOT `id` ^ ?")
+    assert((id2 ^ 1L).statement === "`id` ^ ?")
+    assert((id2 ^ 1L).NOT.statement === "NOT `id` ^ ?")
   }
 
   it should "The string constructed by the expression syntax that performs the right shift operation to determine if it matches matches the specified string." in {
-    assert((id1 >> 1L).statement === "id >> ?")
-    assert((id1 >> 1L).NOT.statement === "NOT id >> ?")
-    assert((id2 >> 1L).statement === "id >> ?")
-    assert((id2 >> 1L).NOT.statement === "NOT id >> ?")
+    assert((id1 >> 1L).statement === "`id` >> ?")
+    assert((id1 >> 1L).NOT.statement === "NOT `id` >> ?")
+    assert((id2 >> 1L).statement === "`id` >> ?")
+    assert((id2 >> 1L).NOT.statement === "NOT `id` >> ?")
   }
 
   it should "The string constructed by the expression syntax that performs addition operations to determine if they match matches the specified string." in {
-    assert(((id1 ++ id1) < 1L).statement === "id + id < ?")
-    assert(((id1 ++ id1) < 1L).NOT.statement === "NOT id + id < ?")
-    assert(((id2 ++ id2) < 1L).statement === "id + id < ?")
-    assert(((id2 ++ id2) < 1L).NOT.statement === "NOT id + id < ?")
+    assert(((id1 ++ id1) < 1L).statement === "`id` + `id` < ?")
+    assert(((id1 ++ id1) < 1L).NOT.statement === "NOT `id` + `id` < ?")
+    assert(((id2 ++ id2) < 1L).statement === "`id` + `id` < ?")
+    assert(((id2 ++ id2) < 1L).NOT.statement === "NOT `id` + `id` < ?")
   }
 
   it should "The string constructed by the expression syntax that performs subtraction operations to determine if they match matches the specified string." in {
-    assert(((id1 -- id1) < 1L).statement === "id - id < ?")
-    assert(((id1 -- id1) < 1L).NOT.statement === "NOT id - id < ?")
-    assert(((id2 -- id2) < 1L).statement === "id - id < ?")
-    assert(((id2 -- id2) < 1L).NOT.statement === "NOT id - id < ?")
+    assert(((id1 -- id1) < 1L).statement === "`id` - `id` < ?")
+    assert(((id1 -- id1) < 1L).NOT.statement === "NOT `id` - `id` < ?")
+    assert(((id2 -- id2) < 1L).statement === "`id` - `id` < ?")
+    assert(((id2 -- id2) < 1L).NOT.statement === "NOT `id` - `id` < ?")
   }
 
   it should "The string constructed by the expression syntax that performs the multiplication operation to determine if it matches matches the specified string." in {
-    assert(((id1 * id1) < 1L).statement === "id * id < ?")
-    assert(((id1 * id1) < 1L).NOT.statement === "NOT id * id < ?")
-    assert(((id2 * id2) < 1L).statement === "id * id < ?")
-    assert(((id2 * id2) < 1L).NOT.statement === "NOT id * id < ?")
+    assert(((id1 * id1) < 1L).statement === "`id` * `id` < ?")
+    assert(((id1 * id1) < 1L).NOT.statement === "NOT `id` * `id` < ?")
+    assert(((id2 * id2) < 1L).statement === "`id` * `id` < ?")
+    assert(((id2 * id2) < 1L).NOT.statement === "NOT `id` * `id` < ?")
   }
 
   it should "The string constructed by the expression syntax that performs the division operation and determines whether it matches matches the specified string." in {
-    assert(((id1 / id1) < 1L).statement === "id / id < ?")
-    assert(((id1 / id1) < 1L).NOT.statement === "NOT id / id < ?")
-    assert(((id2 / id2) < 1L).statement === "id / id < ?")
-    assert(((id2 / id2) < 1L).NOT.statement === "NOT id / id < ?")
+    assert(((id1 / id1) < 1L).statement === "`id` / `id` < ?")
+    assert(((id1 / id1) < 1L).NOT.statement === "NOT `id` / `id` < ?")
+    assert(((id2 / id2) < 1L).statement === "`id` / `id` < ?")
+    assert(((id2 / id2) < 1L).NOT.statement === "NOT `id` / `id` < ?")
   }
 
   it should "The string constructed by the expression syntax, which performs bit inversion to determine if it matches, matches the specified string." in {
-    assert((id1 ~ 1L).statement === "~id = ?")
-    assert((id1 ~ 1L).NOT.statement === "NOT ~id = ?")
-    assert((id2 ~ 1L).statement === "~id = ?")
-    assert((id2 ~ 1L).NOT.statement === "NOT ~id = ?")
+    assert((id1 ~ 1L).statement === "~`id` = ?")
+    assert((id1 ~ 1L).NOT.statement === "NOT ~`id` = ?")
+    assert((id2 ~ 1L).statement === "~`id` = ?")
+    assert((id2 ~ 1L).NOT.statement === "NOT ~`id` = ?")
   }
 
   it should "The query string of the combined expression matches the specified string." in {
     val age = Column.Impl[Option[Int]]("age")
-    assert((id1 === 1L && name1 === "name" || age > 25).statement === "(id = ? AND name = ? OR age > ?)")
+    assert((id1 === 1L && name1 === "name" || age > 25).statement === "(`id` = ? AND `name` = ? OR `age` > ?)")
   }
 
   it should "Comparison operators can also be used when using Opaque Type Alias." in {
-    assert((token1 === Token.fromString("token")).statement === "token = ?")
-    assert((token1 === Token.fromString("token")).NOT.statement === "NOT token = ?")
-    assert((token1 === Token.fromString("token")).statement === "token = ?")
-    assert((token1 === Token.fromString("token")).NOT.statement === "NOT token = ?")
+    assert((token1 === Token.fromString("token")).statement === "`token` = ?")
+    assert((token1 === Token.fromString("token")).NOT.statement === "NOT `token` = ?")
+    assert((token1 === Token.fromString("token")).statement === "`token` = ?")
+    assert((token1 === Token.fromString("token")).NOT.statement === "NOT `token` = ?")
   }
 
   it should "Comparison operators can also be used when using Opaque Type Alias of Option type." in {
-    assert((token2 === Token.fromString("token")).statement === "token = ?")
-    assert((token2 === Token.fromString("token")).NOT.statement === "NOT token = ?")
-    assert((token2 === Token.fromString("token")).statement === "token = ?")
-    assert((token2 === Token.fromString("token")).NOT.statement === "NOT token = ?")
+    assert((token2 === Token.fromString("token")).statement === "`token` = ?")
+    assert((token2 === Token.fromString("token")).NOT.statement === "NOT `token` = ?")
+    assert((token2 === Token.fromString("token")).statement === "`token` = ?")
+    assert((token2 === Token.fromString("token")).NOT.statement === "NOT `token` = ?")
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Statement columns currently generated by the Query Builder are not enclosed in bag quotes. Therefore, using reserved naming in MySQL will result in an error that the query syntax is incorrect.

```scala
case class Hoge(yearMonth: YearMonth) derives Table

println(TableQuery[Hoge].selectAll.statement)
// SELECT year_month FROM hoge
```

Make the change because this problem can be solved by simply enclosing the columns in bag quotation marks.

```scala
case class Hoge(yearMonth: YearMonth) derives Table

println(TableQuery[Hoge].selectAll.statement)
// SELECT `year_month` FROM hoge
```

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/365

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
