### PR TITLE
Enhancement/2025 02 data type column

### DIFF
--- a/benchmark/src/main/scala/benchmark/Model.scala
+++ b/benchmark/src/main/scala/benchmark/Model.scala
@@ -8,7 +8,8 @@ package benchmark
 
 import ldbc.dsl.codec.*
 
-import ldbc.query.builder.formatter.Naming
+import ldbc.statement.formatter.Naming
+
 import ldbc.query.builder.Table
 
 given Naming = Naming.PASCAL

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
@@ -46,6 +46,12 @@ trait Encoder[A]:
   /** `Encoder` is semigroupal: a pair of encoders make a encoder for a pair. */
   def product[B](that: Encoder[B]): Encoder[(A, B)] = (value: (A, B)) => encode(value._1) product that.encode(value._2)
 
+  /** Lift this `Decoder` into `Option`. */
+  def opt: Encoder[Option[A]] = {
+    case Some(value) => this.encode(value)
+    case None => Encoder.Encoded.success(List.empty)
+  }
+
 object Encoder extends TwiddleSyntax[Encoder]:
 
   /** Types that can be handled by PreparedStatement. */

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Encoder.scala
@@ -49,7 +49,7 @@ trait Encoder[A]:
   /** Lift this `Decoder` into `Option`. */
   def opt: Encoder[Option[A]] = {
     case Some(value) => this.encode(value)
-    case None => Encoder.Encoded.success(List.empty)
+    case None        => Encoder.Encoded.success(List.empty)
   }
 
 object Encoder extends TwiddleSyntax[Encoder]:

--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/Table.scala
@@ -13,8 +13,8 @@ import scala.quoted.*
 import ldbc.dsl.codec.*
 
 import ldbc.statement.{ AbstractTable, Column }
+import ldbc.statement.formatter.Naming
 
-import ldbc.query.builder.formatter.Naming
 import ldbc.query.builder.interpreter.*
 import ldbc.query.builder.Column as ColumnAnnotation
 

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Character.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Character.scala
@@ -243,7 +243,7 @@ object Character:
  * A model for representing collations to be set in column definitions for the string data types CHAR, VARCHAR, TEXT,
  * ENUM, SET, and any synonym.
  */
-trait Collate[T <: Collate.COLLATION_TYPE] extends Attribute[T]:
+trait Collate[T] extends Attribute[T]:
 
   /** Collate name */
   def name: String

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -127,7 +127,9 @@ object DataTypeColumn:
     override def updateStatement:             String = s"$name = ?"
     override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
-    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def default(value: T): DataTypeColumn[T] = value match
+      case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
+      case v            => this.copy(defaultValue = Some(Default.Value(v)))
     override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
@@ -163,7 +165,9 @@ object DataTypeColumn:
     override def updateStatement:             String = s"$name = ?"
     override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
-    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def default(value: T): DataTypeColumn[T] = value match
+      case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
+      case v            => this.copy(defaultValue = Some(Default.Value(v)))
     override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
@@ -195,7 +199,9 @@ object DataTypeColumn:
     override def updateStatement:             String = s"$name = ?"
     override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
-    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def default(value: T): DataTypeColumn[T] = value match
+      case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
+      case v            => this.copy(defaultValue = Some(Default.Value(v)))
     override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
@@ -228,7 +234,9 @@ object DataTypeColumn:
     override def updateStatement:             String = s"$name = ?"
     override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
-    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def default(value: T): DataTypeColumn[T] = value match
+      case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
+      case v            => this.copy(defaultValue = Some(Default.Value(v)))
     override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -233,14 +233,50 @@ object DataTypeColumn:
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
-  def apply[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): DataTypeColumn[T] =
-    Impl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def apply[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using
+    codec: Codec[T]
+  ): DataTypeColumn[T] =
+    Impl[T](
+      s"`$name`",
+      alias.map(v => s"$v.`$name`"),
+      codec.asDecoder,
+      codec.asEncoder,
+      dataType,
+      isOptional = isOptional
+    )
 
-  def numeric[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): NumericColumn[T] =
-    NumericColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def numeric[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using
+    codec: Codec[T]
+  ): NumericColumn[T] =
+    NumericColumnImpl[T](
+      s"`$name`",
+      alias.map(v => s"$v.`$name`"),
+      codec.asDecoder,
+      codec.asEncoder,
+      dataType,
+      isOptional = isOptional
+    )
 
-  def string[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): StringColumn[T] =
-    StringColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def string[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using
+    codec: Codec[T]
+  ): StringColumn[T] =
+    StringColumnImpl[T](
+      s"`$name`",
+      alias.map(v => s"$v.`$name`"),
+      codec.asDecoder,
+      codec.asEncoder,
+      dataType,
+      isOptional = isOptional
+    )
 
-  def temporal[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): TemporalColumn[T] =
-    TemporalColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def temporal[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using
+    codec: Codec[T]
+  ): TemporalColumn[T] =
+    TemporalColumnImpl[T](
+      s"`$name`",
+      alias.map(v => s"$v.`$name`"),
+      codec.asDecoder,
+      codec.asEncoder,
+      dataType,
+      isOptional = isOptional
+    )

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -130,7 +130,7 @@ object DataTypeColumn:
     override def default(value: T): DataTypeColumn[T] = value match
       case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
       case v            => this.copy(defaultValue = Some(Default.Value(v)))
-    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
     override def autoIncrement: NumericColumn[T] = this.copy(attributes = AutoInc[T]() :: attributes)
@@ -168,7 +168,7 @@ object DataTypeColumn:
     override def default(value: T): DataTypeColumn[T] = value match
       case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
       case v            => this.copy(defaultValue = Some(Default.Value(v)))
-    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
@@ -202,7 +202,7 @@ object DataTypeColumn:
     override def default(value: T): DataTypeColumn[T] = value match
       case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
       case v            => this.copy(defaultValue = Some(Default.Value(v)))
-    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
@@ -237,7 +237,7 @@ object DataTypeColumn:
     override def default(value: T): DataTypeColumn[T] = value match
       case v: Option[?] => this.copy(defaultValue = Some(v.fold(Default.Null)(Default.Value(_))))
       case v            => this.copy(defaultValue = Some(Default.Value(v)))
-    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.schema
+
+import ldbc.dsl.codec.*
+
+import ldbc.statement.Column
+
+import ldbc.schema.attribute.{Attribute, AutoInc}
+
+sealed trait DataTypeColumn[T] extends Column[T]:
+
+  /**
+   * Data type to be set for the column
+   */
+  def dataType: DataType[T]
+  
+  /**
+   * List of attributes to be set for the column
+   */
+  def attributes: List[Attribute[T]]
+
+  /**
+   * Default value to be set for the column
+   */
+  def defaultValue: Option[Default]
+
+  /**
+   * Method for setting the default value to the current time.
+   */
+  def default(value: T): DataTypeColumn[T]
+
+  /**
+   * Method for setting the default value to NULL.
+   */
+  def defaultNull: DataTypeColumn[T]
+
+  /**
+   * Method for setting the attributes to the column.
+   */
+  def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T]
+
+  /**
+   * Value indicating whether DataType is null-allowed or not.
+   *
+   * @return
+   * true if NULL is allowed, false if NULL is not allowed
+   */
+  def isOptional: Boolean
+
+  /**
+   * Value to indicate whether NULL is acceptable as a query string in SQL
+   */
+  protected def nullType: String = if isOptional then "NULL" else "NOT NULL"
+
+object DataTypeColumn:
+
+  sealed trait NumericColumn[T] extends DataTypeColumn[T]:
+
+    /**
+     * Method for setting data type to unsigned.
+     */
+    def unsigned: NumericColumn[T]
+
+    /**
+     * Method for setting the default value to AUTO_INCREMENT.
+     */
+    def autoIncrement: NumericColumn[T]
+
+  sealed trait StringColumn[T] extends DataTypeColumn[T]:
+
+    /**
+     * Method for setting Character Set to DataType in SQL.
+     *
+     * @param character
+     * Character Set
+     */
+    def charset(character: Character): StringColumn[T]
+
+    /**
+     * Method for setting Collation to DataType in SQL.
+     *
+     * @param collate
+     * Collation
+     */
+    def collate(collate: Collate[T]): StringColumn[T]
+
+  sealed trait TemporalColumn[T] extends DataTypeColumn[T]:
+
+    /**
+     * Method for setting the default value to the current time.
+     */
+    def defaultCurrentTimestamp(onUpdate: Boolean = false): TemporalColumn[T]
+
+    /**
+     * Method for setting the default value to the current date.
+     */
+    def defaultCurrentDate: TemporalColumn[T]
+
+  private[ldbc] case class NumericColumnImpl[T](
+                                                name:       String,
+                                                alias:      Option[String],
+                                                decoder:    Decoder[T],
+                                                encoder:    Encoder[T],
+                                                dataType:   DataType[T],
+                                                isUnsigned: Boolean = false,
+                                                isOptional: Boolean = true,
+                                                defaultValue: Option[Default] = None,
+                                                attributes: List[Attribute[T]] = List.empty[Attribute[T]],
+                                              ) extends NumericColumn[T]:
+
+    override def as(name: String): Column[T] =
+      this.copy(alias = Some(name))
+
+    override def statement: String =
+      (List(
+        Some(name),
+        Some(dataType.typeName),
+        if isUnsigned then Some("UNSIGNED") else None,
+        Some(nullType),
+        defaultValue.map(_.queryString)
+      ).flatten ++ attributes.map(_.queryString)).mkString(" ")
+    override def updateStatement: String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+
+    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+
+    override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
+    override def autoIncrement: NumericColumn[T] = this.copy(attributes = AutoInc[T]() :: attributes)
+
+    override def unsigned: NumericColumn[T] = this.copy(isUnsigned = true)
+
+  private[ldbc] case class StringColumnImpl[T](
+                                                name:       String,
+                                                alias:      Option[String],
+                                                decoder:    Decoder[T],
+                                                encoder:    Encoder[T],
+                                                dataType:   DataType[T],
+                                                isOptional: Boolean = true,
+                                                attributes: List[Attribute[T]] = List.empty[Attribute[T]],
+                                                defaultValue: Option[Default] = None,
+                                                character:  Option[Character]  = None,
+                                                collate:    Option[Collate[T]] = None,
+                                              ) extends StringColumn[T]:
+
+    override def as(name: String): Column[T] =
+      this.copy(alias = Some(name))
+
+    override def statement: String =
+      (List(
+        Some(name),
+        Some(dataType.typeName),
+        character.map(_.queryString),
+        collate.map(_.queryString),
+        Some(nullType),
+        defaultValue.map(_.queryString),
+      ).flatten ++ attributes.map(_.queryString)).mkString(" ")
+    override def updateStatement: String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+
+    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+
+    override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
+
+    override def charset(character: Character): StringColumn[T] = this.copy(character = Some(character))
+    override def collate(collate: Collate[T]): StringColumn[T] = this.copy(collate = Some(collate))
+
+  private[ldbc] case class TemporalColumnImpl[T](
+                                                  name:       String,
+                                                  alias:      Option[String],
+                                                  decoder:    Decoder[T],
+                                                  encoder:    Encoder[T],
+                                                  dataType:   DataType[T],
+                                                  isOptional: Boolean = true,
+                                                  attributes: List[Attribute[T]] = List.empty[Attribute[T]],
+                                                  defaultValue: Option[Default] = None,
+                                                ) extends TemporalColumn[T]:
+
+    override def as(name: String): Column[T] =
+      this.copy(alias = Some(name))
+
+    override def statement: String =
+      (List(
+        Some(name),
+        Some(dataType.typeName),
+        Some(nullType),
+        defaultValue.map(_.queryString),
+      ).flatten ++ attributes.map(_.queryString)).mkString(" ")
+    override def updateStatement: String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+
+    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+
+    override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
+
+    override def defaultCurrentTimestamp(onUpdate: Boolean = false): TemporalColumn[T] = this.copy(defaultValue = Some(Default.TimeStamp(None, onUpdate)))
+    override def defaultCurrentDate: TemporalColumn[T] = this.copy(defaultValue = Some(Default.Date()))
+
+  private[ldbc] case class Impl[T](
+                                    name:       String,
+                                    alias:      Option[String],
+                                    decoder:    Decoder[T],
+                                    encoder:    Encoder[T],
+                                    dataType:   DataType[T],
+                                    isOptional: Boolean = true,
+                                    attributes: List[Attribute[T]] = List.empty[Attribute[T]],
+                                    defaultValue: Option[Default] = None
+                                  ) extends DataTypeColumn[T]:
+
+    override def as(name: String): Column[T] =
+      this.copy(alias = Some(name))
+    
+    override def statement: String =
+      (List(
+        Some(name),
+        Some(dataType.typeName),
+        Some(nullType),
+        defaultValue.map(_.queryString),
+      ).flatten ++ attributes.map(_.queryString)).mkString(" ")
+    override def updateStatement: String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+
+    override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
+    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+
+    override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
+
+  def apply[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): DataTypeColumn[T] =
+    Impl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+
+  def numeric[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): NumericColumn[T] =
+    NumericColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+
+  def string[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): StringColumn[T] =
+    StringColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+
+  def temporal[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): TemporalColumn[T] =
+    TemporalColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -10,7 +10,7 @@ import ldbc.dsl.codec.*
 
 import ldbc.statement.Column
 
-import ldbc.schema.attribute.{Attribute, AutoInc}
+import ldbc.schema.attribute.{ Attribute, AutoInc }
 
 sealed trait DataTypeColumn[T] extends Column[T]:
 
@@ -18,7 +18,7 @@ sealed trait DataTypeColumn[T] extends Column[T]:
    * Data type to be set for the column
    */
   def dataType: DataType[T]
-  
+
   /**
    * List of attributes to be set for the column
    */
@@ -102,16 +102,16 @@ object DataTypeColumn:
     def defaultCurrentDate: TemporalColumn[T]
 
   private[ldbc] case class NumericColumnImpl[T](
-                                                name:       String,
-                                                alias:      Option[String],
-                                                decoder:    Decoder[T],
-                                                encoder:    Encoder[T],
-                                                dataType:   DataType[T],
-                                                isUnsigned: Boolean = false,
-                                                isOptional: Boolean = true,
-                                                defaultValue: Option[Default] = None,
-                                                attributes: List[Attribute[T]] = List.empty[Attribute[T]],
-                                              ) extends NumericColumn[T]:
+    name:         String,
+    alias:        Option[String],
+    decoder:      Decoder[T],
+    encoder:      Encoder[T],
+    dataType:     DataType[T],
+    isUnsigned:   Boolean            = false,
+    isOptional:   Boolean            = true,
+    defaultValue: Option[Default]    = None,
+    attributes:   List[Attribute[T]] = List.empty[Attribute[T]]
+  ) extends NumericColumn[T]:
 
     override def as(name: String): Column[T] =
       this.copy(alias = Some(name))
@@ -124,11 +124,11 @@ object DataTypeColumn:
         Some(nullType),
         defaultValue.map(_.queryString)
       ).flatten ++ attributes.map(_.queryString)).mkString(" ")
-    override def updateStatement: String = s"$name = ?"
-    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+    override def updateStatement:             String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
     override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
-    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
     override def autoIncrement: NumericColumn[T] = this.copy(attributes = AutoInc[T]() :: attributes)
@@ -136,17 +136,17 @@ object DataTypeColumn:
     override def unsigned: NumericColumn[T] = this.copy(isUnsigned = true)
 
   private[ldbc] case class StringColumnImpl[T](
-                                                name:       String,
-                                                alias:      Option[String],
-                                                decoder:    Decoder[T],
-                                                encoder:    Encoder[T],
-                                                dataType:   DataType[T],
-                                                isOptional: Boolean = true,
-                                                attributes: List[Attribute[T]] = List.empty[Attribute[T]],
-                                                defaultValue: Option[Default] = None,
-                                                character:  Option[Character]  = None,
-                                                collate:    Option[Collate[T]] = None,
-                                              ) extends StringColumn[T]:
+    name:         String,
+    alias:        Option[String],
+    decoder:      Decoder[T],
+    encoder:      Encoder[T],
+    dataType:     DataType[T],
+    isOptional:   Boolean            = true,
+    attributes:   List[Attribute[T]] = List.empty[Attribute[T]],
+    defaultValue: Option[Default]    = None,
+    character:    Option[Character]  = None,
+    collate:      Option[Collate[T]] = None
+  ) extends StringColumn[T]:
 
     override def as(name: String): Column[T] =
       this.copy(alias = Some(name))
@@ -158,29 +158,29 @@ object DataTypeColumn:
         character.map(_.queryString),
         collate.map(_.queryString),
         Some(nullType),
-        defaultValue.map(_.queryString),
+        defaultValue.map(_.queryString)
       ).flatten ++ attributes.map(_.queryString)).mkString(" ")
-    override def updateStatement: String = s"$name = ?"
-    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+    override def updateStatement:             String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
     override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
-    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
-    override def charset(character: Character): StringColumn[T] = this.copy(character = Some(character))
-    override def collate(collate: Collate[T]): StringColumn[T] = this.copy(collate = Some(collate))
+    override def charset(character: Character):  StringColumn[T] = this.copy(character = Some(character))
+    override def collate(collate:   Collate[T]): StringColumn[T] = this.copy(collate = Some(collate))
 
   private[ldbc] case class TemporalColumnImpl[T](
-                                                  name:       String,
-                                                  alias:      Option[String],
-                                                  decoder:    Decoder[T],
-                                                  encoder:    Encoder[T],
-                                                  dataType:   DataType[T],
-                                                  isOptional: Boolean = true,
-                                                  attributes: List[Attribute[T]] = List.empty[Attribute[T]],
-                                                  defaultValue: Option[Default] = None,
-                                                ) extends TemporalColumn[T]:
+    name:         String,
+    alias:        Option[String],
+    decoder:      Decoder[T],
+    encoder:      Encoder[T],
+    dataType:     DataType[T],
+    isOptional:   Boolean            = true,
+    attributes:   List[Attribute[T]] = List.empty[Attribute[T]],
+    defaultValue: Option[Default]    = None
+  ) extends TemporalColumn[T]:
 
     override def as(name: String): Column[T] =
       this.copy(alias = Some(name))
@@ -190,45 +190,46 @@ object DataTypeColumn:
         Some(name),
         Some(dataType.typeName),
         Some(nullType),
-        defaultValue.map(_.queryString),
+        defaultValue.map(_.queryString)
       ).flatten ++ attributes.map(_.queryString)).mkString(" ")
-    override def updateStatement: String = s"$name = ?"
-    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+    override def updateStatement:             String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
     override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
-    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
-    override def defaultCurrentTimestamp(onUpdate: Boolean = false): TemporalColumn[T] = this.copy(defaultValue = Some(Default.TimeStamp(None, onUpdate)))
+    override def defaultCurrentTimestamp(onUpdate: Boolean = false): TemporalColumn[T] =
+      this.copy(defaultValue = Some(Default.TimeStamp(None, onUpdate)))
     override def defaultCurrentDate: TemporalColumn[T] = this.copy(defaultValue = Some(Default.Date()))
 
   private[ldbc] case class Impl[T](
-                                    name:       String,
-                                    alias:      Option[String],
-                                    decoder:    Decoder[T],
-                                    encoder:    Encoder[T],
-                                    dataType:   DataType[T],
-                                    isOptional: Boolean = true,
-                                    attributes: List[Attribute[T]] = List.empty[Attribute[T]],
-                                    defaultValue: Option[Default] = None
-                                  ) extends DataTypeColumn[T]:
+    name:         String,
+    alias:        Option[String],
+    decoder:      Decoder[T],
+    encoder:      Encoder[T],
+    dataType:     DataType[T],
+    isOptional:   Boolean            = true,
+    attributes:   List[Attribute[T]] = List.empty[Attribute[T]],
+    defaultValue: Option[Default]    = None
+  ) extends DataTypeColumn[T]:
 
     override def as(name: String): Column[T] =
       this.copy(alias = Some(name))
-    
+
     override def statement: String =
       (List(
         Some(name),
         Some(dataType.typeName),
         Some(nullType),
-        defaultValue.map(_.queryString),
+        defaultValue.map(_.queryString)
       ).flatten ++ attributes.map(_.queryString)).mkString(" ")
-    override def updateStatement: String = s"$name = ?"
-    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${alias.getOrElse(name)})"
+    override def updateStatement:             String = s"$name = ?"
+    override def duplicateKeyUpdateStatement: String = s"$name = VALUES(${ alias.getOrElse(name) })"
 
     override def default(value: T): DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Value(value)))
-    override def defaultNull: DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
+    override def defaultNull:       DataTypeColumn[T] = this.copy(defaultValue = Some(Default.Null))
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypeColumn.scala
@@ -233,14 +233,14 @@ object DataTypeColumn:
 
     override def setAttributes(attributes: Attribute[T]*): DataTypeColumn[T] = this.copy(attributes = attributes.toList)
 
-  def apply[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): DataTypeColumn[T] =
-    Impl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def apply[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): DataTypeColumn[T] =
+    Impl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
 
-  def numeric[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): NumericColumn[T] =
-    NumericColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def numeric[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): NumericColumn[T] =
+    NumericColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
 
-  def string[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): StringColumn[T] =
-    StringColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def string[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): StringColumn[T] =
+    StringColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
 
-  def temporal[T](name: String, dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): TemporalColumn[T] =
-    TemporalColumnImpl[T](s"`$name`", None, codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)
+  def temporal[T](name: String, alias: Option[String], dataType: DataType[T], isOptional: Boolean)(using codec: Codec[T]): TemporalColumn[T] =
+    TemporalColumnImpl[T](s"`$name`", alias.map(v => s"$v.`$name`"), codec.asDecoder, codec.asEncoder, dataType, isOptional = isOptional)

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -25,11 +25,12 @@ import scala.quoted.*
 import ldbc.dsl.codec.Codec
 
 import ldbc.statement.{ AbstractTable, Column }
-import ldbc.statement.formatter.Naming
 
 import ldbc.schema.attribute.Attribute
 import ldbc.schema.interpreter.*
 import ldbc.schema.model.{ Enum as EnumModel, EnumDataType }
+import ldbc.schema.DataType.*
+import ldbc.schema.macros.DataTypeColumnMacros.*
 
 trait Table[T](val $name: String) extends AbstractTable[T]:
 
@@ -61,6 +62,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), BIT, Table.isOptional[A])
 
+  protected final inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.bit[A]($name)
+
   /**
    * Create a column with a data type of TINYINT.
    */
@@ -68,6 +72,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), TINYINT, Table.isOptional[A])
+
+  protected final inline def tinyint[A <: Byte | Short | Option[Byte | Short]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.tinyint[A]($name)
 
   /**
    * Create a column with a data type of SMALLINT.
@@ -77,6 +84,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), SMALLINT, Table.isOptional[A])
 
+  protected final inline def smallint[A <: Short | Int | Option[Short | Int]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.smallint[A]($name)
+
   /**
    * Create a column with a data type of MEDIUMINT.
    */
@@ -84,6 +94,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), MEDIUMINT, Table.isOptional[A])
+
+  protected final inline def mediumint[A <: Int | Option[Int]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.mediumint[A]($name)
 
   /**
    * Create a column with a data type of INT.
@@ -104,6 +117,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), BIGINT, Table.isOptional[A])
 
+  protected final inline def bigint[A <: Long | BigInt | Option[Long | BigInt]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.bigint[A]($name)
+
   /**
    * Create a column with a data type of DECIMAL.
    */
@@ -114,6 +130,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   )(using Codec[A]): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric[A](name, Some($name), DECIMAL(accuracy, scale), Table.isOptional[A])
 
+  protected final inline def decimal[A <: BigDecimal | Option[BigDecimal]]: (Int, Int) => DataTypeColumn.NumericColumn[A] =
+    Table.decimal[A]($name)
+
   /**
    * Create a column with a data type of FLOAT.
    */
@@ -121,6 +140,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric[A](name, Some($name), FLOAT(accuracy), Table.isOptional[A])
+
+  protected final inline def float[A <: Float | Option[Float]]: Int => DataTypeColumn.NumericColumn[A] =
+    Table.float[A]($name)
 
   /**
    * Create a column with a data type of DOUBLE.
@@ -130,6 +152,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric[A](name, Some($name), DOUBLE(accuracy), Table.isOptional[A])
 
+  protected final inline def double[A <: Double | Option[Double]]: Int => DataTypeColumn.NumericColumn[A] =
+    Table.double[A]($name)
+
   /**
    * Create a column with a data type of CHAR.
    */
@@ -137,6 +162,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), CHAR(length), Table.isOptional)
+
+  protected final inline def char[A <: String | Option[String]]: Int => DataTypeColumn.StringColumn[A] =
+    Table.char[A]($name)
 
   /**
    * Create a column with a data type of VARCHAR.
@@ -146,6 +174,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), VARCHAR(length), Table.isOptional)
 
+  protected final inline def varchar[A <: String | Option[String]]: Int => DataTypeColumn.StringColumn[A] =
+    Table.varchar[A]($name)
+
   /**
    * Create a column with a data type of BINARY.
    */
@@ -153,6 +184,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), BINARY(length), Table.isOptional)
+
+  protected final inline def binary[A <: Array[Byte] | Option[Array[Byte]]]: Int => DataTypeColumn.StringColumn[A] =
+    Table.binary[A]($name)
 
   /**
    * Create a column with a data type of VARBINARY.
@@ -162,6 +196,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), VARBINARY(length), Table.isOptional)
 
+  protected final inline def varbinary[A <: Array[Byte] | Option[Array[Byte]]]: Int => DataTypeColumn.StringColumn[A] =
+    Table.varbinary[A]($name)
+
   /**
    * Create a column with a data type of TINYBLOB.
    */
@@ -169,6 +206,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), TINYBLOB(), Table.isOptional)
+
+  protected final inline def tinyblob[A <: Array[Byte] | Option[Array[Byte]]]: () => DataTypeColumn.StringColumn[A] =
+    Table.tinyblob[A]($name)
 
   /**
    * Create a column with a data type of BLOB.
@@ -178,6 +218,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), BLOB(), Table.isOptional)
 
+  protected final inline def blob[A <: Array[Byte] | Option[Array[Byte]]]: () => DataTypeColumn.StringColumn[A] =
+    Table.blob[A]($name)
+
   /**
    * Create a column with a data type of MEDIUMBLOB.
    */
@@ -185,6 +228,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), MEDIUMBLOB(), Table.isOptional)
+
+  protected final inline def mediumblob[A <: Array[Byte] | Option[Array[Byte]]]: () => DataTypeColumn.StringColumn[A] =
+    Table.mediumblob[A]($name)
 
   /**
    * Create a column with a data type of LONGBLOB.
@@ -194,6 +240,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), LONGBLOB(), Table.isOptional)
 
+  protected final inline def longblob[A <: Array[Byte] | Option[Array[Byte]]]: () => DataTypeColumn.StringColumn[A] =
+    Table.longblob[A]($name)
+
   /**
    * Create a column with a data type of TINYTEXT.
    */
@@ -201,6 +250,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), TINYTEXT(), Table.isOptional)
+
+  protected final inline def tinytext[A <: String | Option[String]]: () => DataTypeColumn.StringColumn[A] =
+    Table.tinytext[A]($name)
 
   /**
    * Create a column with a data type of TEXT.
@@ -210,6 +262,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), TEXT(), Table.isOptional)
 
+  protected final inline def text[A <: String | Option[String]]: () => DataTypeColumn.StringColumn[A] =
+    Table.text[A]($name)
+
   /**
    * Create a column with a data type of MEDIUMTEXT.
    */
@@ -218,6 +273,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), MEDIUMTEXT(), Table.isOptional)
 
+  protected final inline def mediumtext[A <: String | Option[String]]: () => DataTypeColumn.StringColumn[A] =
+    Table.mediumtext[A]($name)
+
   /**
    * Create a column with a data type of LONGTEXT.
    */
@@ -225,6 +283,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.StringColumn[A] =
     DataTypeColumn.string[A](name, Some($name), LONGTEXT(), Table.isOptional)
+
+  protected final inline def longtext[A <: String | Option[String]]: () => DataTypeColumn.StringColumn[A] =
+    Table.longtext[A]($name)
 
   /**
    * Create a column with a data type of ENUM.
@@ -242,6 +303,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), DATE, Table.isOptional)
 
+  protected final inline def date[A <: String | LocalDate | Option[String | LocalDate]]: () => DataTypeColumn.TemporalColumn[A] =
+    Table.date[A]($name)
+
   /**
    * Create a column with a data type of DATETIME.
    */
@@ -249,6 +313,11 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     A <: String | Instant | LocalDateTime | OffsetTime | Option[String | Instant | LocalDateTime | OffsetTime]
   ](name: String)(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), DATETIME, Table.isOptional)
+
+  protected final inline def datetime[
+    A <: String | Instant | LocalDateTime | OffsetTime | Option[String | Instant | LocalDateTime | OffsetTime]
+  ]: () => DataTypeColumn.TemporalColumn[A] =
+    Table.datetime[A]($name)
 
   /**
    * Create a column with a data type of TIMESTAMP.
@@ -259,6 +328,12 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ](name: String)(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), TIMESTAMP, Table.isOptional)
 
+  protected final inline def timestamp[
+    A <: String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ]: () => DataTypeColumn.TemporalColumn[A] =
+    Table.timestamp[A]($name)
+
   /**
    * Create a column with a data type of TIME.
    */
@@ -266,6 +341,9 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
     Codec[A]
   ): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), TIME, Table.isOptional)
+
+  protected final inline def time[A <: String | LocalTime | Option[String | LocalTime]]: () => DataTypeColumn.TemporalColumn[A] =
+    Table.time[A]($name)
 
   /**
    * Create a column with a data type of YEAR.
@@ -275,17 +353,26 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   )(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), YEAR, Table.isOptional)
 
+  protected final inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]]: () => DataTypeColumn.TemporalColumn[A] =
+    Table.year[A]($name)
+
   /**
    * Create a column with a data type of SERIAL.
    */
   protected final inline def serial[A <: BigInt](name: String)(using Codec[A]): DataTypeColumn[A] =
     DataTypeColumn[A](name, Some($name), SERIAL, Table.isOptional)
 
+  protected final inline def serial[A <: BigInt]: () => DataTypeColumn[A] =
+    Table.serial[A]($name)
+
   /**
    * Create a column with a data type of BOOLEAN.
    */
   protected final inline def boolean[A <: Boolean | Option[Boolean]](name: String)(using Codec[A]): DataTypeColumn[A] =
     DataTypeColumn[A](name, Some($name), BOOLEAN, Table.isOptional)
+
+  protected final inline def boolean[A <: Boolean | Option[Boolean]]: () => DataTypeColumn[A] =
+    Table.boolean[A]($name)
 
   /**
    * Methods for setting key information for tables.
@@ -315,36 +402,94 @@ object Table:
     case _: Option[?] => true
     case _            => false
 
-  private[ldbc] def namedNumericColumnImpl[A](
-    alias:      Expr[Option[String]],
-    dataType:   Expr[DataType[A]],
-    isOptional: Expr[Boolean]
-  )(using
-    q:   Quotes,
-    tpe: Type[A]
-  ): Expr[() => DataTypeColumn.NumericColumn[A]] =
-    import quotes.reflect.*
+  inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+    ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'BIT, 'isOptional) }
 
-    @scala.annotation.tailrec()
-    def enclosingTerm(sym: Symbol): Symbol =
-      sym match
-        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
-        case _                             => sym
+  inline def tinyint[A <: Byte | Short | Option[Byte | Short]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+    ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'TINYINT, 'isOptional) }
 
-    val codec = Expr.summon[Codec[A]].getOrElse {
-      report.errorAndAbort(s"Codec for type $tpe not found")
-    }
+  inline def smallint[A <: Short | Int | Option[Short | Int]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+    ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'SMALLINT, 'isOptional) }
 
-    val naming = Expr.summon[Naming] match
-      case Some(naming) => naming
-      case None         => '{ Naming.SNAKE }
-
-    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
-    '{ () => DataTypeColumn.numeric[A]($name, $alias, $dataType, $isOptional)(using $codec) }
+  inline def mediumint[A <: Int | Option[Int]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+    ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'MEDIUMINT, 'isOptional) }
 
   inline def int[A <: Int | Long | Option[Int | Long]](alias: String): () => DataTypeColumn.NumericColumn[A] =
     ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'INT, 'isOptional) }
+
+  inline def bigint[A <: Long | BigInt | Option[Long | BigInt]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+    ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'BIGINT, 'isOptional) }
+
+  inline def decimal[A <: BigDecimal | Option[BigDecimal]](alias: String): (Int, Int) => DataTypeColumn.NumericColumn[A] =
+    ${ namedDecimalColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int, scale: Int) => Decimal(accuracy, scale, isOptional[A]) }, 'isOptional) }
+
+  inline def float[A <: Float | Option[Float]](alias: String): Int => DataTypeColumn.NumericColumn[A] =
+    ${ namedDoubleColumnImpl[A]('{ Some(alias) }, '{  (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional) }
+
+  inline def double[A <: Double | Option[Double]](alias: String): Int => DataTypeColumn.NumericColumn[A] =
+    ${ namedDoubleColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional) }
+
+  inline def char[A <: String | Option[String]](alias: String): Int => DataTypeColumn.StringColumn[A] =
+    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => CChar(length, isOptional[A]) }, 'isOptional) }
+
+  inline def varchar[A <: String | Option[String]](alias: String): Int => DataTypeColumn.StringColumn[A] =
+    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Varchar(length, isOptional[A]) }, 'isOptional) }
+
+  inline def binary[A <: Array[Byte] | Option[Array[Byte]]](alias: String): Int => DataTypeColumn.StringColumn[A] =
+    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Binary(length, isOptional[A]) }, 'isOptional) }
+
+  inline def varbinary[A <: Array[Byte] | Option[Array[Byte]]](alias: String): Int => DataTypeColumn.StringColumn[A] =
+    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Varbinary(length, isOptional[A]) }, 'isOptional) }
+
+  inline def tinyblob[A <: Array[Byte] | Option[Array[Byte]]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ TINYBLOB() }, 'isOptional) }
+
+  inline def blob[A <: Array[Byte] | Option[Array[Byte]]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ BLOB() }, 'isOptional) }
+
+  inline def mediumblob[A <: Array[Byte] | Option[Array[Byte]]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ MEDIUMBLOB() }, 'isOptional) }
+
+  inline def longblob[A <: Array[Byte] | Option[Array[Byte]]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ LONGBLOB() }, 'isOptional) }
+
+  inline def tinytext[A <: String | Option[String]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ TINYTEXT() }, 'isOptional) }
+
+  inline def text[A <: String | Option[String]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ TEXT() }, 'isOptional) }
+
+  inline def mediumtext[A <: String | Option[String]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ MEDIUMTEXT() }, 'isOptional) }
+
+  inline def longtext[A <: String | Option[String]](alias: String): () => DataTypeColumn.StringColumn[A] =
+    ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ LONGTEXT() }, 'isOptional) }
+
+  inline def date[A <: String | LocalDate | Option[String | LocalDate]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+    ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'DATE, 'isOptional) }
+
+  inline def datetime[
+    A <: String | Instant | LocalDateTime | OffsetTime | Option[String | Instant | LocalDateTime | OffsetTime]
+  ](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+    ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'DATETIME, 'isOptional) }
+
+  inline def timestamp[
+    A <: String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+    ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'TIMESTAMP, 'isOptional) }
+
+  inline def time[A <: String | LocalTime | Option[String | LocalTime]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+    ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'TIME, 'isOptional) }
+
+  inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+    ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'YEAR, 'isOptional) }
+
+  inline def serial[A <: BigInt](alias: String): () => DataTypeColumn[A] =
+    ${ namedColumnImpl[A]('{ Some(alias) }, 'SERIAL, 'isOptional) }
+
+  inline def boolean[A <: Boolean | Option[Boolean]](alias: String): () => DataTypeColumn[A] =
+    ${ namedColumnImpl[A]('{ Some(alias) }, 'BOOLEAN, 'isOptional) }
 
   case class Opt[T](
     $name:   String,

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -6,6 +6,18 @@
 
 package ldbc.schema
 
+import java.time.{
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  OffsetDateTime,
+  OffsetTime,
+  Year as JYear,
+  ZonedDateTime
+}
+
+import scala.compiletime.erasedValue
 import scala.deriving.Mirror
 import scala.language.dynamics
 
@@ -15,10 +27,15 @@ import ldbc.statement.{ AbstractTable, Column }
 
 import ldbc.schema.attribute.Attribute
 import ldbc.schema.interpreter.*
+import ldbc.schema.model.{ Enum as EnumModel, EnumDataType }
 
 trait Table[T](val $name: String) extends AbstractTable[T]:
 
   export ldbc.statement.Column
+
+  transparent inline private def isOptional[A] = inline erasedValue[A] match
+    case _: Option[?] => true
+    case _            => false
 
   protected final def column[A](name: String)(using codec: Codec[A]): Column[A] =
     ColumnImpl[A](s"`$name`", Some(s"${ $name }.`$name`"), codec.asDecoder, codec.asEncoder, None, List.empty)
@@ -37,6 +54,237 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
       Some(dataType),
       attributes.toList
     )
+
+  /**
+   * Create a column with a data type of BIT.
+   */
+  protected final inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, BIT, isOptional[A])
+
+  /**
+   * Create a column with a data type of TINYINT.
+   */
+  protected final inline def tinyint[A <: Byte | Short | Option[Byte | Short]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, TINYINT, isOptional[A])
+
+  /**
+   * Create a column with a data type of SMALLINT.
+   */
+  protected final inline def smallint[A <: Short | Int | Option[Short | Int]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, SMALLINT, isOptional[A])
+
+  /**
+   * Create a column with a data type of MEDIUMINT.
+   */
+  protected final inline def mediumint[A <: Int | Option[Int]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, MEDIUMINT, isOptional[A])
+
+  /**
+   * Create a column with a data type of INT.
+   */
+  protected final inline def int[A <: Int | Long | Option[Int | Long]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, INT, isOptional[A])
+
+  /**
+   * Create a column with a data type of BIGINT.
+   */
+  protected final inline def bigint[A <: Long | BigInt | Option[Long | BigInt]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric(name, BIGINT, isOptional[A])
+
+  /**
+   * Create a column with a data type of DECIMAL.
+   */
+  protected final inline def decimal[A <: BigDecimal | Option[BigDecimal]](
+    inline accuracy: Int = 10,
+    inline scale:    Int = 0,
+    name:            String
+  )(using Codec[A]): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric[A](name, DECIMAL(accuracy, scale), isOptional[A])
+
+  /**
+   * Create a column with a data type of FLOAT.
+   */
+  protected final inline def float[A <: Float | Option[Float]](inline accuracy: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric[A](name, FLOAT(accuracy), isOptional[A])
+
+  /**
+   * Create a column with a data type of DOUBLE.
+   */
+  protected final inline def double[A <: Double | Option[Double]](inline accuracy: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.NumericColumn[A] =
+    DataTypeColumn.numeric[A](name, DOUBLE(accuracy), isOptional[A])
+
+  /**
+   * Create a column with a data type of CHAR.
+   */
+  protected final inline def char[A <: String | Option[String]](inline length: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, CHAR(length), isOptional)
+
+  /**
+   * Create a column with a data type of VARCHAR.
+   */
+  protected final inline def varchar[A <: String | Option[String]](inline length: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, VARCHAR(length), isOptional)
+
+  /**
+   * Create a column with a data type of BINARY.
+   */
+  protected final inline def binary[A <: Array[Byte] | Option[Array[Byte]]](inline length: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, BINARY(length), isOptional)
+
+  /**
+   * Create a column with a data type of VARBINARY.
+   */
+  protected final inline def varbinary[A <: Array[Byte] | Option[Array[Byte]]](inline length: Int, name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, VARBINARY(length), isOptional)
+
+  /**
+   * Create a column with a data type of TINYBLOB.
+   */
+  protected final inline def tinyblob[A <: Array[Byte] | Option[Array[Byte]]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, TINYBLOB(), isOptional)
+
+  /**
+   * Create a column with a data type of BLOB.
+   */
+  protected final inline def blob[A <: Array[Byte] | Option[Array[Byte]]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, BLOB(), isOptional)
+
+  /**
+   * Create a column with a data type of MEDIUMBLOB.
+   */
+  protected final inline def mediumblob[A <: Array[Byte] | Option[Array[Byte]]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, MEDIUMBLOB(), isOptional)
+
+  /**
+   * Create a column with a data type of LONGBLOB.
+   */
+  protected final inline def longblob[A <: Array[Byte] | Option[Array[Byte]]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, LONGBLOB(), isOptional)
+
+  /**
+   * Create a column with a data type of TINYTEXT.
+   */
+  protected final inline def tinytext[A <: String | Option[String]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, TINYTEXT(), isOptional)
+
+  /**
+   * Create a column with a data type of TEXT.
+   */
+  protected final inline def text[A <: String | Option[String]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, TEXT(), isOptional)
+
+  /**
+   * Create a column with a data type of MEDIUMTEXT.
+   */
+  protected final inline def mediumtext[A <: String | Option[String]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, MEDIUMTEXT(), isOptional)
+
+  /**
+   * Create a column with a data type of LONGTEXT.
+   */
+  protected final inline def longtext[A <: String | Option[String]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, LONGTEXT(), isOptional)
+
+  /**
+   * Create a column with a data type of ENUM.
+   */
+  protected final inline def `enum`[A <: EnumModel | Option[EnumModel]](
+    name: String
+  )(using Codec[A], EnumDataType[?]): DataTypeColumn.StringColumn[A] =
+    DataTypeColumn.string[A](name, ENUM, isOptional)
+
+  /**
+   * Create a column with a data type of DATE.
+   */
+  protected final inline def date[A <: String | LocalDate | Option[String | LocalDate]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.TemporalColumn[A] =
+    DataTypeColumn.temporal[A](name, DATE, isOptional)
+
+  /**
+   * Create a column with a data type of DATETIME.
+   */
+  protected final inline def datetime[
+    A <: String | Instant | LocalDateTime | OffsetTime | Option[String | Instant | LocalDateTime | OffsetTime]
+  ](name: String)(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
+    DataTypeColumn.temporal[A](name, DATETIME, isOptional)
+
+  /**
+   * Create a column with a data type of TIMESTAMP.
+   */
+  protected final inline def timestamp[
+    A <: String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime |
+      Option[String | Instant | LocalDateTime | OffsetDateTime | ZonedDateTime]
+  ](name: String)(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
+    DataTypeColumn.temporal[A](name, TIMESTAMP, isOptional)
+
+  /**
+   * Create a column with a data type of TIME.
+   */
+  protected final inline def time[A <: String | LocalTime | Option[String | LocalTime]](name: String)(using
+    Codec[A]
+  ): DataTypeColumn.TemporalColumn[A] =
+    DataTypeColumn.temporal[A](name, TIME, isOptional)
+
+  /**
+   * Create a column with a data type of YEAR.
+   */
+  protected final inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]](
+    name: String
+  )(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
+    DataTypeColumn.temporal[A](name, YEAR, isOptional)
+
+  /**
+   * Create a column with a data type of SERIAL.
+   */
+  protected final inline def serial[A <: BigInt](name: String)(using Codec[A]): DataTypeColumn[A] =
+    DataTypeColumn[A](name, SERIAL, isOptional)
+
+  /**
+   * Create a column with a data type of BOOLEAN.
+   */
+  protected final inline def boolean[A <: Boolean | Option[Boolean]](name: String)(using Codec[A]): DataTypeColumn[A] =
+    DataTypeColumn[A](name, BOOLEAN, isOptional)
 
   /**
    * Methods for setting key information for tables.

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -28,9 +28,9 @@ import ldbc.statement.{ AbstractTable, Column }
 
 import ldbc.schema.attribute.Attribute
 import ldbc.schema.interpreter.*
+import ldbc.schema.macros.DataTypeColumnMacros.*
 import ldbc.schema.model.{ Enum as EnumModel, EnumDataType }
 import ldbc.schema.DataType.*
-import ldbc.schema.macros.DataTypeColumnMacros.*
 
 trait Table[T](val $name: String) extends AbstractTable[T]:
 
@@ -62,7 +62,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), BIT, Table.isOptional[A])
 
-  protected final inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]]: () => DataTypeColumn.NumericColumn[A] =
+  protected final inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]]
+    : () => DataTypeColumn.NumericColumn[A] =
     Table.bit[A]($name)
 
   /**
@@ -130,7 +131,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   )(using Codec[A]): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric[A](name, Some($name), DECIMAL(accuracy, scale), Table.isOptional[A])
 
-  protected final inline def decimal[A <: BigDecimal | Option[BigDecimal]]: (Int, Int) => DataTypeColumn.NumericColumn[A] =
+  protected final inline def decimal[A <: BigDecimal | Option[BigDecimal]]
+    : (Int, Int) => DataTypeColumn.NumericColumn[A] =
     Table.decimal[A]($name)
 
   /**
@@ -303,7 +305,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), DATE, Table.isOptional)
 
-  protected final inline def date[A <: String | LocalDate | Option[String | LocalDate]]: () => DataTypeColumn.TemporalColumn[A] =
+  protected final inline def date[A <: String | LocalDate | Option[String | LocalDate]]
+    : () => DataTypeColumn.TemporalColumn[A] =
     Table.date[A]($name)
 
   /**
@@ -342,7 +345,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), TIME, Table.isOptional)
 
-  protected final inline def time[A <: String | LocalTime | Option[String | LocalTime]]: () => DataTypeColumn.TemporalColumn[A] =
+  protected final inline def time[A <: String | LocalTime | Option[String | LocalTime]]
+    : () => DataTypeColumn.TemporalColumn[A] =
     Table.time[A]($name)
 
   /**
@@ -353,7 +357,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   )(using Codec[A]): DataTypeColumn.TemporalColumn[A] =
     DataTypeColumn.temporal[A](name, Some($name), YEAR, Table.isOptional)
 
-  protected final inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]]: () => DataTypeColumn.TemporalColumn[A] =
+  protected final inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]]
+    : () => DataTypeColumn.TemporalColumn[A] =
     Table.year[A]($name)
 
   /**
@@ -402,7 +407,9 @@ object Table:
     case _: Option[?] => true
     case _            => false
 
-  inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]](alias: String): () => DataTypeColumn.NumericColumn[A] =
+  inline def bit[A <: Byte | Short | Int | Long | Option[Byte | Short | Int | Long]](
+    alias: String
+  ): () => DataTypeColumn.NumericColumn[A] =
     ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'BIT, 'isOptional) }
 
   inline def tinyint[A <: Byte | Short | Option[Byte | Short]](alias: String): () => DataTypeColumn.NumericColumn[A] =
@@ -420,26 +427,54 @@ object Table:
   inline def bigint[A <: Long | BigInt | Option[Long | BigInt]](alias: String): () => DataTypeColumn.NumericColumn[A] =
     ${ namedNumericColumnImpl[A]('{ Some(alias) }, 'BIGINT, 'isOptional) }
 
-  inline def decimal[A <: BigDecimal | Option[BigDecimal]](alias: String): (Int, Int) => DataTypeColumn.NumericColumn[A] =
-    ${ namedDecimalColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int, scale: Int) => Decimal(accuracy, scale, isOptional[A]) }, 'isOptional) }
+  inline def decimal[A <: BigDecimal | Option[BigDecimal]](
+    alias: String
+  ): (Int, Int) => DataTypeColumn.NumericColumn[A] =
+    ${
+      namedDecimalColumnImpl[A](
+        '{ Some(alias) },
+        '{ (accuracy: Int, scale: Int) => Decimal(accuracy, scale, isOptional[A]) },
+        'isOptional
+      )
+    }
 
   inline def float[A <: Float | Option[Float]](alias: String): Int => DataTypeColumn.NumericColumn[A] =
-    ${ namedDoubleColumnImpl[A]('{ Some(alias) }, '{  (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional) }
+    ${
+      namedDoubleColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional)
+    }
 
   inline def double[A <: Double | Option[Double]](alias: String): Int => DataTypeColumn.NumericColumn[A] =
-    ${ namedDoubleColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional) }
+    ${
+      namedDoubleColumnImpl[A]('{ Some(alias) }, '{ (accuracy: Int) => CFloat(accuracy, isOptional[A]) }, 'isOptional)
+    }
 
   inline def char[A <: String | Option[String]](alias: String): Int => DataTypeColumn.StringColumn[A] =
-    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => CChar(length, isOptional[A]) }, 'isOptional) }
+    ${
+      namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => CChar(length, isOptional[A]) }, 'isOptional)
+    }
 
   inline def varchar[A <: String | Option[String]](alias: String): Int => DataTypeColumn.StringColumn[A] =
-    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Varchar(length, isOptional[A]) }, 'isOptional) }
+    ${
+      namedStringLengthColumnImpl[A](
+        '{ Some(alias) },
+        '{ (length: Int) => Varchar(length, isOptional[A]) },
+        'isOptional
+      )
+    }
 
   inline def binary[A <: Array[Byte] | Option[Array[Byte]]](alias: String): Int => DataTypeColumn.StringColumn[A] =
-    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Binary(length, isOptional[A]) }, 'isOptional) }
+    ${
+      namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Binary(length, isOptional[A]) }, 'isOptional)
+    }
 
   inline def varbinary[A <: Array[Byte] | Option[Array[Byte]]](alias: String): Int => DataTypeColumn.StringColumn[A] =
-    ${ namedStringLengthColumnImpl[A]('{ Some(alias) }, '{ (length: Int) => Varbinary(length, isOptional[A]) }, 'isOptional) }
+    ${
+      namedStringLengthColumnImpl[A](
+        '{ Some(alias) },
+        '{ (length: Int) => Varbinary(length, isOptional[A]) },
+        'isOptional
+      )
+    }
 
   inline def tinyblob[A <: Array[Byte] | Option[Array[Byte]]](alias: String): () => DataTypeColumn.StringColumn[A] =
     ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ TINYBLOB() }, 'isOptional) }
@@ -465,7 +500,9 @@ object Table:
   inline def longtext[A <: String | Option[String]](alias: String): () => DataTypeColumn.StringColumn[A] =
     ${ namedStringColumnImpl[A]('{ Some(alias) }, '{ LONGTEXT() }, 'isOptional) }
 
-  inline def date[A <: String | LocalDate | Option[String | LocalDate]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+  inline def date[A <: String | LocalDate | Option[String | LocalDate]](
+    alias: String
+  ): () => DataTypeColumn.TemporalColumn[A] =
     ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'DATE, 'isOptional) }
 
   inline def datetime[
@@ -479,10 +516,14 @@ object Table:
   ](alias: String): () => DataTypeColumn.TemporalColumn[A] =
     ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'TIMESTAMP, 'isOptional) }
 
-  inline def time[A <: String | LocalTime | Option[String | LocalTime]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+  inline def time[A <: String | LocalTime | Option[String | LocalTime]](
+    alias: String
+  ): () => DataTypeColumn.TemporalColumn[A] =
     ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'TIME, 'isOptional) }
 
-  inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]](alias: String): () => DataTypeColumn.TemporalColumn[A] =
+  inline def year[A <: Int | Instant | LocalDate | JYear | Option[Int | Instant | LocalDate | JYear]](
+    alias: String
+  ): () => DataTypeColumn.TemporalColumn[A] =
     ${ namedTemporalColumnImpl[A]('{ Some(alias) }, 'YEAR, 'isOptional) }
 
   inline def serial[A <: BigInt](alias: String): () => DataTypeColumn[A] =

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/Table.scala
@@ -24,7 +24,7 @@ import scala.quoted.*
 
 import ldbc.dsl.codec.Codec
 
-import ldbc.statement.{AbstractTable, Column}
+import ldbc.statement.{ AbstractTable, Column }
 import ldbc.statement.formatter.Naming
 
 import ldbc.schema.attribute.Attribute
@@ -93,7 +93,8 @@ trait Table[T](val $name: String) extends AbstractTable[T]:
   ): DataTypeColumn.NumericColumn[A] =
     DataTypeColumn.numeric(name, Some($name), INT, Table.isOptional[A])
 
-  protected final inline def int[A <: Int | Long | Option[Int | Long]]: () => DataTypeColumn.NumericColumn[A] = Table.int[A]($name)
+  protected final inline def int[A <: Int | Long | Option[Int | Long]]: () => DataTypeColumn.NumericColumn[A] =
+    Table.int[A]($name)
 
   /**
    * Create a column with a data type of BIGINT.
@@ -314,7 +315,11 @@ object Table:
     case _: Option[?] => true
     case _            => false
 
-  private[ldbc] def namedNumericColumnImpl[A](alias: Expr[Option[String]], dataType: Expr[DataType[A]], isOptional: Expr[Boolean])(using
+  private[ldbc] def namedNumericColumnImpl[A](
+    alias:      Expr[Option[String]],
+    dataType:   Expr[DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
     q:   Quotes,
     tpe: Type[A]
   ): Expr[() => DataTypeColumn.NumericColumn[A]] =
@@ -333,7 +338,7 @@ object Table:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ () => DataTypeColumn.numeric[A]($name, $alias, $dataType, $isOptional)(using $codec) }

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/attribute/AutoInc.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/attribute/AutoInc.scala
@@ -9,7 +9,7 @@ package ldbc.schema.attribute
 /**
  * Model for specifying an additional attribute AUTO_INCREMENT for DataType.
  */
-private[ldbc] case class AutoInc[T <: Byte | Short | Int | Long | BigInt | Option[Byte | Short | Int | Long | BigInt]]()
+private[ldbc] case class AutoInc[T]()
   extends Attribute[T]:
 
   override def queryString: String = "AUTO_INCREMENT"

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/attribute/AutoInc.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/attribute/AutoInc.scala
@@ -9,8 +9,7 @@ package ldbc.schema.attribute
 /**
  * Model for specifying an additional attribute AUTO_INCREMENT for DataType.
  */
-private[ldbc] case class AutoInc[T]()
-  extends Attribute[T]:
+private[ldbc] case class AutoInc[T]() extends Attribute[T]:
 
   override def queryString: String = "AUTO_INCREMENT"
 

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/macros/DataTypeColumnMacros.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/macros/DataTypeColumnMacros.scala
@@ -17,21 +17,21 @@ import ldbc.schema.*
 object DataTypeColumnMacros:
 
   def namedColumnImpl[A](
-                                 alias: Expr[Option[String]],
-                                 dataType: Expr[DataType[A]],
-                                 isOptional: Expr[Boolean]
-                               )(using
-                                 q: Quotes,
-                                 tpe: Type[A]
-                               ): Expr[() => DataTypeColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[() => DataTypeColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -39,27 +39,27 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ () => DataTypeColumn.apply[A]($name, $alias, $dataType, $isOptional)(using $codec) }
 
   def namedNumericColumnImpl[A](
-                                               alias:      Expr[Option[String]],
-                                               dataType:   Expr[DataType[A]],
-                                               isOptional: Expr[Boolean]
-                                             )(using
-                                               q:   Quotes,
-                                               tpe: Type[A]
-                                             ): Expr[() => DataTypeColumn.NumericColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[() => DataTypeColumn.NumericColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -73,21 +73,21 @@ object DataTypeColumnMacros:
     '{ () => DataTypeColumn.numeric[A]($name, $alias, $dataType, $isOptional)(using $codec) }
 
   def namedDecimalColumnImpl[A](
-                                               alias: Expr[Option[String]],
-                                               dataType: Expr[(Int, Int) => DataType[A]],
-                                               isOptional: Expr[Boolean]
-                                             )(using
-                                               q: Quotes,
-                                               tpe: Type[A]
-                                             ): Expr[(Int, Int) => DataTypeColumn.NumericColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[(Int, Int) => DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[(Int, Int) => DataTypeColumn.NumericColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -95,27 +95,29 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
-    '{ (accuracy: Int, scale: Int) => DataTypeColumn.numeric[A]($name, $alias, $dataType(accuracy, scale), $isOptional)(using $codec) }
+    '{ (accuracy: Int, scale: Int) =>
+      DataTypeColumn.numeric[A]($name, $alias, $dataType(accuracy, scale), $isOptional)(using $codec)
+    }
 
   def namedDoubleColumnImpl[A](
-                                 alias: Expr[Option[String]],
-                                 dataType: Expr[Int => DataType[A]],
-                                 isOptional: Expr[Boolean]
-                               )(using
-                                 q: Quotes,
-                                 tpe: Type[A]
-                               ): Expr[Int => DataTypeColumn.NumericColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[Int => DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[Int => DataTypeColumn.NumericColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -123,27 +125,27 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ (accuracy: Int) => DataTypeColumn.numeric[A]($name, $alias, $dataType(accuracy), $isOptional)(using $codec) }
 
   def namedStringColumnImpl[A](
-                                      alias: Expr[Option[String]],
-                                      dataType: Expr[DataType[A]],
-                                      isOptional: Expr[Boolean]
-                                    )(using
-                                      q: Quotes,
-                                      tpe: Type[A]
-                                    ): Expr[() => DataTypeColumn.StringColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[() => DataTypeColumn.StringColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -151,27 +153,27 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ () => DataTypeColumn.string[A]($name, $alias, $dataType, $isOptional)(using $codec) }
 
   def namedStringLengthColumnImpl[A](
-                                alias: Expr[Option[String]],
-                                dataType: Expr[Int => DataType[A]],
-                                isOptional: Expr[Boolean]
-                              )(using
-                                q: Quotes,
-                                tpe: Type[A]
-                              ): Expr[Int => DataTypeColumn.StringColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[Int => DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[Int => DataTypeColumn.StringColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -179,27 +181,27 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ (length: Int) => DataTypeColumn.string[A]($name, $alias, $dataType(length), $isOptional)(using $codec) }
 
   def namedTemporalColumnImpl[A](
-                                alias: Expr[Option[String]],
-                                dataType: Expr[DataType[A]],
-                                isOptional: Expr[Boolean]
-                              )(using
-                                q: Quotes,
-                                tpe: Type[A]
-                              ): Expr[() => DataTypeColumn.TemporalColumn[A]] =
+    alias:      Expr[Option[String]],
+    dataType:   Expr[DataType[A]],
+    isOptional: Expr[Boolean]
+  )(using
+    q:   Quotes,
+    tpe: Type[A]
+  ): Expr[() => DataTypeColumn.TemporalColumn[A]] =
     import quotes.reflect.*
 
     @scala.annotation.tailrec()
     def enclosingTerm(sym: Symbol): Symbol =
       sym match
         case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
-        case _ if !sym.isTerm => enclosingTerm(sym.owner)
-        case _ => sym
+        case _ if !sym.isTerm              => enclosingTerm(sym.owner)
+        case _                             => sym
 
     val codec = Expr.summon[Codec[A]].getOrElse {
       report.errorAndAbort(s"Codec for type $tpe not found")
@@ -207,7 +209,7 @@ object DataTypeColumnMacros:
 
     val naming = Expr.summon[Naming] match
       case Some(naming) => naming
-      case None => '{ Naming.SNAKE }
+      case None         => '{ Naming.SNAKE }
 
     val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
     '{ () => DataTypeColumn.temporal[A]($name, $alias, $dataType, $isOptional)(using $codec) }

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/macros/DataTypeColumnMacros.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/macros/DataTypeColumnMacros.scala
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.schema.macros
+
+import scala.quoted.*
+
+import ldbc.dsl.codec.Codec
+
+import ldbc.statement.formatter.Naming
+
+import ldbc.schema.*
+
+object DataTypeColumnMacros:
+
+  def namedColumnImpl[A](
+                                 alias: Expr[Option[String]],
+                                 dataType: Expr[DataType[A]],
+                                 isOptional: Expr[Boolean]
+                               )(using
+                                 q: Quotes,
+                                 tpe: Type[A]
+                               ): Expr[() => DataTypeColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ () => DataTypeColumn.apply[A]($name, $alias, $dataType, $isOptional)(using $codec) }
+
+  def namedNumericColumnImpl[A](
+                                               alias:      Expr[Option[String]],
+                                               dataType:   Expr[DataType[A]],
+                                               isOptional: Expr[Boolean]
+                                             )(using
+                                               q:   Quotes,
+                                               tpe: Type[A]
+                                             ): Expr[() => DataTypeColumn.NumericColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None         => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ () => DataTypeColumn.numeric[A]($name, $alias, $dataType, $isOptional)(using $codec) }
+
+  def namedDecimalColumnImpl[A](
+                                               alias: Expr[Option[String]],
+                                               dataType: Expr[(Int, Int) => DataType[A]],
+                                               isOptional: Expr[Boolean]
+                                             )(using
+                                               q: Quotes,
+                                               tpe: Type[A]
+                                             ): Expr[(Int, Int) => DataTypeColumn.NumericColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ (accuracy: Int, scale: Int) => DataTypeColumn.numeric[A]($name, $alias, $dataType(accuracy, scale), $isOptional)(using $codec) }
+
+  def namedDoubleColumnImpl[A](
+                                 alias: Expr[Option[String]],
+                                 dataType: Expr[Int => DataType[A]],
+                                 isOptional: Expr[Boolean]
+                               )(using
+                                 q: Quotes,
+                                 tpe: Type[A]
+                               ): Expr[Int => DataTypeColumn.NumericColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ (accuracy: Int) => DataTypeColumn.numeric[A]($name, $alias, $dataType(accuracy), $isOptional)(using $codec) }
+
+  def namedStringColumnImpl[A](
+                                      alias: Expr[Option[String]],
+                                      dataType: Expr[DataType[A]],
+                                      isOptional: Expr[Boolean]
+                                    )(using
+                                      q: Quotes,
+                                      tpe: Type[A]
+                                    ): Expr[() => DataTypeColumn.StringColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ () => DataTypeColumn.string[A]($name, $alias, $dataType, $isOptional)(using $codec) }
+
+  def namedStringLengthColumnImpl[A](
+                                alias: Expr[Option[String]],
+                                dataType: Expr[Int => DataType[A]],
+                                isOptional: Expr[Boolean]
+                              )(using
+                                q: Quotes,
+                                tpe: Type[A]
+                              ): Expr[Int => DataTypeColumn.StringColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ (length: Int) => DataTypeColumn.string[A]($name, $alias, $dataType(length), $isOptional)(using $codec) }
+
+  def namedTemporalColumnImpl[A](
+                                alias: Expr[Option[String]],
+                                dataType: Expr[DataType[A]],
+                                isOptional: Expr[Boolean]
+                              )(using
+                                q: Quotes,
+                                tpe: Type[A]
+                              ): Expr[() => DataTypeColumn.TemporalColumn[A]] =
+    import quotes.reflect.*
+
+    @scala.annotation.tailrec()
+    def enclosingTerm(sym: Symbol): Symbol =
+      sym match
+        case _ if sym.flags is Flags.Macro => enclosingTerm(sym.owner)
+        case _ if !sym.isTerm => enclosingTerm(sym.owner)
+        case _ => sym
+
+    val codec = Expr.summon[Codec[A]].getOrElse {
+      report.errorAndAbort(s"Codec for type $tpe not found")
+    }
+
+    val naming = Expr.summon[Naming] match
+      case Some(naming) => naming
+      case None => '{ Naming.SNAKE }
+
+    val name = '{ $naming.format(${ Expr(enclosingTerm(Symbol.spliceOwner).name) }) }
+    '{ () => DataTypeColumn.temporal[A]($name, $alias, $dataType, $isOptional)(using $codec) }

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
@@ -6,7 +6,7 @@
 
 package ldbc.schema
 
-import java.time.{LocalDate, LocalTime, LocalDateTime, Year}
+import java.time.{ LocalDate, LocalDateTime, LocalTime, Year }
 
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -17,62 +17,62 @@ import ldbc.schema.DataType.*
 class TableCreateStatementTest extends AnyFlatSpec:
 
   case class AllDataTypes(
-                           c1: Option[Short],
-                           c2: Option[Short],
-                           c3: Option[Int],
-                           c4: Option[Int],
-                           c5: Long,
-                           c6: Option[BigDecimal],
-                           c7: Option[Float],
-                           c8: Option[Double],
-                           c9: Option[Byte],
-                           c10: Option[String],
-                           c11: Option[String],
-                           c12: Option[Array[Byte]],
-                           c13: Array[Byte],
-                           c14: Option[String],
-                           c15: Option[String],
-                           c16: Option[String],
-                           c17: String,
-                           c18: Array[Byte],
-                           c19: Option[Array[Byte]],
-                           c20: Option[Array[Byte]],
-                           c21: Option[Array[Byte]],
-                           c22: Option[LocalDate],
-                           c23: Option[LocalTime],
-                           c24: Option[LocalDateTime],
-                           c25: Option[LocalDateTime],
-                           c26: Option[Year]
-                         )
+    c1:  Option[Short],
+    c2:  Option[Short],
+    c3:  Option[Int],
+    c4:  Option[Int],
+    c5:  Long,
+    c6:  Option[BigDecimal],
+    c7:  Option[Float],
+    c8:  Option[Double],
+    c9:  Option[Byte],
+    c10: Option[String],
+    c11: Option[String],
+    c12: Option[Array[Byte]],
+    c13: Array[Byte],
+    c14: Option[String],
+    c15: Option[String],
+    c16: Option[String],
+    c17: String,
+    c18: Array[Byte],
+    c19: Option[Array[Byte]],
+    c20: Option[Array[Byte]],
+    c21: Option[Array[Byte]],
+    c22: Option[LocalDate],
+    c23: Option[LocalTime],
+    c24: Option[LocalDateTime],
+    c25: Option[LocalDateTime],
+    c26: Option[Year]
+  )
 
   class AllDataTypesTable extends Table[AllDataTypes]("all_data_types"):
 
-    def c1: Column[Option[Short]] = smallint().unsigned.autoIncrement
-    def c2: Column[Option[Short]] = smallint().default(Some(-1000))
-    def c3: Column[Option[Int]] = mediumint().unsigned.default(Some(100000))
-    def c4: Column[Option[Int]] = int().default(Some(42))
-    def c5: Column[Long] = bigint().default(9999999999L)
-    def c6: Column[Option[BigDecimal]] = decimal(10, 2).default(Some(123.45))
-    def c7: Column[Option[Float]] = float(10).default(Some(3.142f))
-    def c8: Column[Option[Double]] = double(10).default(Some(2.71828))
-    def c9: Column[Option[Byte]] = bit()
-    def c10: Column[Option[String]] = char(50).default(Some("FIXED"))
-    def c11: Column[Option[String]] = varchar(255).defaultNull
-    def c12: Column[Option[Array[Byte]]] = binary(10)
-    def c13: Column[Array[Byte]] = varbinary(255)
-    def c14: Column[Option[String]] = tinytext().charset(Character.utf8mb4)
-    def c15: Column[Option[String]] = text().collate(Collate.utf8mb4_unicode_ci)
-    def c16: Column[Option[String]] = mediumtext().charset(Character.utf8mb4).collate(Collate.utf8mb4_unicode_ci)
-    def c17: Column[String] = longtext().default("")
-    def c18: Column[Array[Byte]] = tinyblob()
-    def c19: Column[Option[Array[Byte]]] = blob().defaultNull
-    def c20: Column[Option[Array[Byte]]] = mediumblob()
-    def c21: Column[Option[Array[Byte]]] = longblob()
-    def c22: Column[Option[LocalDate]] = date().default(Some(LocalDate.of(2025, 2, 15)))
-    def c23: Column[Option[LocalTime]] = time().default(Some(LocalTime.of(12, 0, 0)))
+    def c1:  Column[Option[Short]]         = smallint().unsigned.autoIncrement
+    def c2:  Column[Option[Short]]         = smallint().default(Some(-1000))
+    def c3:  Column[Option[Int]]           = mediumint().unsigned.default(Some(100000))
+    def c4:  Column[Option[Int]]           = int().default(Some(42))
+    def c5:  Column[Long]                  = bigint().default(9999999999L)
+    def c6:  Column[Option[BigDecimal]]    = decimal(10, 2).default(Some(123.45))
+    def c7:  Column[Option[Float]]         = float(10).default(Some(3.142f))
+    def c8:  Column[Option[Double]]        = double(10).default(Some(2.71828))
+    def c9:  Column[Option[Byte]]          = bit()
+    def c10: Column[Option[String]]        = char(50).default(Some("FIXED"))
+    def c11: Column[Option[String]]        = varchar(255).defaultNull
+    def c12: Column[Option[Array[Byte]]]   = binary(10)
+    def c13: Column[Array[Byte]]           = varbinary(255)
+    def c14: Column[Option[String]]        = tinytext().charset(Character.utf8mb4)
+    def c15: Column[Option[String]]        = text().collate(Collate.utf8mb4_unicode_ci)
+    def c16: Column[Option[String]]        = mediumtext().charset(Character.utf8mb4).collate(Collate.utf8mb4_unicode_ci)
+    def c17: Column[String]                = longtext().default("")
+    def c18: Column[Array[Byte]]           = tinyblob()
+    def c19: Column[Option[Array[Byte]]]   = blob().defaultNull
+    def c20: Column[Option[Array[Byte]]]   = mediumblob()
+    def c21: Column[Option[Array[Byte]]]   = longblob()
+    def c22: Column[Option[LocalDate]]     = date().default(Some(LocalDate.of(2025, 2, 15)))
+    def c23: Column[Option[LocalTime]]     = time().default(Some(LocalTime.of(12, 0, 0)))
     def c24: Column[Option[LocalDateTime]] = datetime().defaultCurrentTimestamp(false)
     def c25: Column[Option[LocalDateTime]] = timestamp().defaultCurrentTimestamp(true)
-    def c26: Column[Option[Year]] = year().default(Some(Year.of(2025)))
+    def c26: Column[Option[Year]]          = year().default(Some(Year.of(2025)))
 
     override def keys: List[Key] = List(
       PRIMARY_KEY(c5),

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
@@ -53,7 +53,7 @@ class TableCreateStatementTest extends AnyFlatSpec:
     def c4:  Column[Option[Int]]           = int().default(Some(42))
     def c5:  Column[Long]                  = bigint().default(9999999999L)
     def c6:  Column[Option[BigDecimal]]    = decimal(10, 2).default(Some(123.45))
-    def c7:  Column[Option[Float]]         = float(10).default(Some(3.142f))
+    def c7:  Column[Option[Float]]         = float(10)
     def c8:  Column[Option[Double]]        = double(10).default(Some(2.71828))
     def c9:  Column[Option[Byte]]          = bit()
     def c10: Column[Option[String]]        = char(50).default(Some("FIXED"))
@@ -105,7 +105,7 @@ class TableCreateStatementTest extends AnyFlatSpec:
       allDataTypes.table.c6.statement === "`c6` DECIMAL(10, 2) NOT NULL DEFAULT '123.45'"
     )
     assert(
-      allDataTypes.table.c7.statement === "`c7` FLOAT(10) NOT NULL DEFAULT 3.142"
+      allDataTypes.table.c7.statement === "`c7` FLOAT(10) NOT NULL"
     )
     assert(
       allDataTypes.table.c8.statement === "`c8` FLOAT(10) NOT NULL DEFAULT 2.71828"
@@ -177,7 +177,7 @@ class TableCreateStatementTest extends AnyFlatSpec:
           |  `c4` INT NOT NULL DEFAULT 42,
           |  `c5` BIGINT NOT NULL DEFAULT 9999999999,
           |  `c6` DECIMAL(10, 2) NOT NULL DEFAULT '123.45',
-          |  `c7` FLOAT(10) NOT NULL DEFAULT 3.142,
+          |  `c7` FLOAT(10) NOT NULL,
           |  `c8` FLOAT(10) NOT NULL DEFAULT 2.71828,
           |  `c9` BIT NOT NULL,
           |  `c10` CHAR(50) NOT NULL DEFAULT 'FIXED',

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableCreateStatementTest.scala
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.schema
+
+import java.time.{LocalDate, LocalTime, LocalDateTime, Year}
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+import ldbc.statement.Column
+
+import ldbc.schema.DataType.*
+
+class TableCreateStatementTest extends AnyFlatSpec:
+
+  case class AllDataTypes(
+                           c1: Option[Short],
+                           c2: Option[Short],
+                           c3: Option[Int],
+                           c4: Option[Int],
+                           c5: Long,
+                           c6: Option[BigDecimal],
+                           c7: Option[Float],
+                           c8: Option[Double],
+                           c9: Option[Byte],
+                           c10: Option[String],
+                           c11: Option[String],
+                           c12: Option[Array[Byte]],
+                           c13: Array[Byte],
+                           c14: Option[String],
+                           c15: Option[String],
+                           c16: Option[String],
+                           c17: String,
+                           c18: Array[Byte],
+                           c19: Option[Array[Byte]],
+                           c20: Option[Array[Byte]],
+                           c21: Option[Array[Byte]],
+                           c22: Option[LocalDate],
+                           c23: Option[LocalTime],
+                           c24: Option[LocalDateTime],
+                           c25: Option[LocalDateTime],
+                           c26: Option[Year]
+                         )
+
+  class AllDataTypesTable extends Table[AllDataTypes]("all_data_types"):
+
+    def c1: Column[Option[Short]] = smallint().unsigned.autoIncrement
+    def c2: Column[Option[Short]] = smallint().default(Some(-1000))
+    def c3: Column[Option[Int]] = mediumint().unsigned.default(Some(100000))
+    def c4: Column[Option[Int]] = int().default(Some(42))
+    def c5: Column[Long] = bigint().default(9999999999L)
+    def c6: Column[Option[BigDecimal]] = decimal(10, 2).default(Some(123.45))
+    def c7: Column[Option[Float]] = float(10).default(Some(3.142f))
+    def c8: Column[Option[Double]] = double(10).default(Some(2.71828))
+    def c9: Column[Option[Byte]] = bit()
+    def c10: Column[Option[String]] = char(50).default(Some("FIXED"))
+    def c11: Column[Option[String]] = varchar(255).defaultNull
+    def c12: Column[Option[Array[Byte]]] = binary(10)
+    def c13: Column[Array[Byte]] = varbinary(255)
+    def c14: Column[Option[String]] = tinytext().charset(Character.utf8mb4)
+    def c15: Column[Option[String]] = text().collate(Collate.utf8mb4_unicode_ci)
+    def c16: Column[Option[String]] = mediumtext().charset(Character.utf8mb4).collate(Collate.utf8mb4_unicode_ci)
+    def c17: Column[String] = longtext().default("")
+    def c18: Column[Array[Byte]] = tinyblob()
+    def c19: Column[Option[Array[Byte]]] = blob().defaultNull
+    def c20: Column[Option[Array[Byte]]] = mediumblob()
+    def c21: Column[Option[Array[Byte]]] = longblob()
+    def c22: Column[Option[LocalDate]] = date().default(Some(LocalDate.of(2025, 2, 15)))
+    def c23: Column[Option[LocalTime]] = time().default(Some(LocalTime.of(12, 0, 0)))
+    def c24: Column[Option[LocalDateTime]] = datetime().defaultCurrentTimestamp(false)
+    def c25: Column[Option[LocalDateTime]] = timestamp().defaultCurrentTimestamp(true)
+    def c26: Column[Option[Year]] = year().default(Some(Year.of(2025)))
+
+    override def keys: List[Key] = List(
+      PRIMARY_KEY(c5),
+      INDEX_KEY(c10)
+    )
+
+    override def * : Column[AllDataTypes] = (
+      c1 *: c2 *: c3 *: c4 *: c5 *: c6 *: c7 *: c8 *: c9 *: c10 *: c11 *: c12 *: c13 *: c14 *: c15 *: c16 *: c17 *: c18 *: c19 *: c20 *: c21 *: c22 *: c23 *: c24 *: c25 *: c26
+    ).to[AllDataTypes]
+
+  private val allDataTypes = TableQuery[AllDataTypesTable]
+
+  it should "The query string of the Column model generated with only label and DataType matches the specified string." in {
+    assert(
+      allDataTypes.table.c1.statement === "`c1` SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT"
+    )
+    assert(
+      allDataTypes.table.c2.statement === "`c2` SMALLINT NOT NULL DEFAULT -1000"
+    )
+    assert(
+      allDataTypes.table.c3.statement === "`c3` MEDIUMINT UNSIGNED NOT NULL DEFAULT 100000"
+    )
+    assert(
+      allDataTypes.table.c4.statement === "`c4` INT NOT NULL DEFAULT 42"
+    )
+    assert(
+      allDataTypes.table.c5.statement === "`c5` BIGINT NOT NULL DEFAULT 9999999999"
+    )
+    assert(
+      allDataTypes.table.c6.statement === "`c6` DECIMAL(10, 2) NOT NULL DEFAULT '123.45'"
+    )
+    assert(
+      allDataTypes.table.c7.statement === "`c7` FLOAT(10) NOT NULL DEFAULT 3.142"
+    )
+    assert(
+      allDataTypes.table.c8.statement === "`c8` FLOAT(10) NOT NULL DEFAULT 2.71828"
+    )
+    assert(
+      allDataTypes.table.c9.statement === "`c9` BIT NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c10.statement === "`c10` CHAR(50) NOT NULL DEFAULT 'FIXED'"
+    )
+    assert(
+      allDataTypes.table.c11.statement === "`c11` VARCHAR(255) NOT NULL DEFAULT NULL"
+    )
+    assert(
+      allDataTypes.table.c12.statement === "`c12` BINARY(10) NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c13.statement === "`c13` VARBINARY(255) NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c14.statement === "`c14` TINYTEXT CHARACTER SET utf8mb4 NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c15.statement === "`c15` TEXT COLLATE utf8mb4_unicode_ci NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c16.statement === "`c16` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c17.statement === "`c17` LONGTEXT NOT NULL DEFAULT ''"
+    )
+    assert(
+      allDataTypes.table.c18.statement === "`c18` TINYBLOB NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c19.statement === "`c19` BLOB NOT NULL DEFAULT NULL"
+    )
+    assert(
+      allDataTypes.table.c20.statement === "`c20` MEDIUMBLOB NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c21.statement === "`c21` LONGBLOB NOT NULL"
+    )
+    assert(
+      allDataTypes.table.c22.statement === "`c22` DATE NOT NULL DEFAULT '2025-02-15'"
+    )
+    assert(
+      allDataTypes.table.c23.statement === "`c23` TIME NOT NULL DEFAULT '12:00'"
+    )
+    assert(
+      allDataTypes.table.c24.statement === "`c24` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+    )
+    assert(
+      allDataTypes.table.c25.statement === "`c25` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+    )
+    assert(
+      allDataTypes.table.c26.statement === "`c26` YEAR NOT NULL DEFAULT '2025'"
+    )
+  }
+
+  it should "The CREATE statement generated by Table matches the specified value." in {
+    assert(
+      allDataTypes.table.createStatement ===
+        """
+          |CREATE TABLE IF NOT EXISTS `all_data_types` (
+          |  `c1` SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+          |  `c2` SMALLINT NOT NULL DEFAULT -1000,
+          |  `c3` MEDIUMINT UNSIGNED NOT NULL DEFAULT 100000,
+          |  `c4` INT NOT NULL DEFAULT 42,
+          |  `c5` BIGINT NOT NULL DEFAULT 9999999999,
+          |  `c6` DECIMAL(10, 2) NOT NULL DEFAULT '123.45',
+          |  `c7` FLOAT(10) NOT NULL DEFAULT 3.142,
+          |  `c8` FLOAT(10) NOT NULL DEFAULT 2.71828,
+          |  `c9` BIT NOT NULL,
+          |  `c10` CHAR(50) NOT NULL DEFAULT 'FIXED',
+          |  `c11` VARCHAR(255) NOT NULL DEFAULT NULL,
+          |  `c12` BINARY(10) NOT NULL,
+          |  `c13` VARBINARY(255) NOT NULL,
+          |  `c14` TINYTEXT CHARACTER SET utf8mb4 NOT NULL,
+          |  `c15` TEXT COLLATE utf8mb4_unicode_ci NOT NULL,
+          |  `c16` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+          |  `c17` LONGTEXT NOT NULL DEFAULT '',
+          |  `c18` TINYBLOB NOT NULL,
+          |  `c19` BLOB NOT NULL DEFAULT NULL,
+          |  `c20` MEDIUMBLOB NOT NULL,
+          |  `c21` LONGBLOB NOT NULL,
+          |  `c22` DATE NOT NULL DEFAULT '2025-02-15',
+          |  `c23` TIME NOT NULL DEFAULT '12:00',
+          |  `c24` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          |  `c25` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          |  `c26` YEAR NOT NULL DEFAULT '2025',
+          |  PRIMARY KEY (`c5`),
+          |  INDEX (`c10`)
+          |)
+          |""".stripMargin
+    )
+  }

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/TableTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/TableTest.scala
@@ -17,9 +17,9 @@ class TableTest extends AnyFlatSpec:
       case class User(id: Long, name: String, age: Int)
 
       class UserTable extends Table[User]("user"):
-        def id: Column[Long] = column[Long]("id", BIGINT, AUTO_INCREMENT)
-        def name: Column[String] = column[String]("name", VARCHAR(255))
-        def age: Column[Int] = column[Int]("age", INT)
+        def id: Column[Long] = bigint("id").autoIncrement
+        def name: Column[String] = varchar(255, "name")
+        def age: Column[Int] = int("age")
 
         override def * = (id *: name *: age).to[User]
     """.stripMargin)
@@ -32,9 +32,9 @@ class TableTest extends AnyFlatSpec:
       case class User(id: Long, name: String, age: Int)
 
       class UserTable extends Table[User]("user"):
-        def id: Column[Long] = column[Long]("id", BIGINT)
-        def name: Column[String] = column[String]("name", VARCHAR(255), AUTO_INCREMENT)
-        def age: Column[Int] = column[Int]("age", INT)
+        def id: Column[Long] = bigint("id")
+        def name: Column[String] = varchar(255, "name").autoIncrement
+        def age: Column[Int] = int("age")
 
         override def * = (id *: name *: age).to[User]
     """.stripMargin)
@@ -63,16 +63,16 @@ class TableTest extends AnyFlatSpec:
       case class SubTest(id: Long, test: String)
 
       class SubTestTable extends Table[SubTest]("sub_test"):
-        def id: Column[Long] = column[Long]("id", BIGINT, AUTO_INCREMENT)
-        def test: Column[String] = column[String]("test", VARCHAR(255))
+        def id: Column[Long] = bigint("id").autoIncrement
+        def test: Column[String] = varchar(255, "test")
 
         override def * = (id *: test).to[SubTest]
 
       val subTest = TableQuery[SubTestTable]
 
       class TestTable extends Table[Test]("test"):
-        def id: Column[Long] = column[Long]("id", BIGINT, AUTO_INCREMENT)
-        def subId: Column[Long] = column[Long]("sub_id", BIGINT)
+        def id: Column[Long] = bigint("id").autoIncrement
+        def subId: Column[Long] = bigint("sub_id")
 
         override def * = (id *: subId).to[Test]
 

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/formatter/Naming.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/formatter/Naming.scala
@@ -1,10 +1,4 @@
-/**
- * Copyright (c) 2023-2024 by Takahiko Tominaga
- * This software is licensed under the MIT License (MIT).
- * For more information see LICENSE or https://opensource.org/licenses/MIT
- */
-
-package ldbc.query.builder.formatter
+package ldbc.statement.formatter
 
 import scala.annotation.tailrec
 
@@ -12,7 +6,7 @@ import scala.annotation.tailrec
  * Enum of naming rules
  */
 enum Naming:
-  case CAMEL, PASCAL, SNAKE, KEBAB
+  case CAMEL, PASCAL, SNAKE
 
 object Naming:
 
@@ -21,10 +15,9 @@ object Naming:
       case "CAMEL"  => CAMEL
       case "PASCAL" => PASCAL
       case "SNAKE"  => SNAKE
-      case "KEBAB"  => KEBAB
       case unknown =>
         throw new IllegalArgumentException(
-          s"$unknown does not match any of the Naming, it must be CAMEL, PASCAL, SNAKE, or KEBAB."
+          s"$unknown does not match any of the Naming, it must be CAMEL, PASCAL, SNAKE."
         )
 
   extension (`case`: Naming)
@@ -33,7 +26,6 @@ object Naming:
         case CAMEL  => toCamel(name)
         case PASCAL => toPascal(name)
         case SNAKE  => toSnake(name)
-        case KEBAB  => toKebab(name)
 
   /**
    * Converts to camelCase e.g.: PascalCase => pascalCase
@@ -77,19 +69,3 @@ object Naming:
       case a :: b :: tail if a.isLower && b.isUpper                   => go(accDone ++ List(a, '_', b), tail)
       case a :: tail                                                  => go(accDone :+ a, tail)
     go(Nil, name.toList).mkString.toLowerCase.replaceAll("-", "_")
-
-  /**
-   * Converts to kebab-case e.g.: camelCase => camel-case
-   *
-   * @param name
-   *   name to be converted to kebab-case
-   * @return
-   *   kebab-case version of the string passed
-   */
-  def toKebab(name: String): String =
-    @tailrec def go(accDone: List[Char], acc: List[Char]): List[Char] = acc match
-      case Nil                                                        => accDone
-      case a :: b :: c :: tail if a.isUpper && b.isUpper && c.isLower => go(accDone ++ List(a, '-', b, c), tail)
-      case a :: b :: tail if a.isLower && b.isUpper                   => go(accDone ++ List(a, '-', b), tail)
-      case a :: tail                                                  => go(accDone :+ a, tail)
-    go(Nil, name.toList).mkString.toLowerCase.replaceAll("_", "-")

--- a/module/ldbc-statement/src/main/scala/ldbc/statement/formatter/Naming.scala
+++ b/module/ldbc-statement/src/main/scala/ldbc/statement/formatter/Naming.scala
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023-2024 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
 package ldbc.statement.formatter
 
 import scala.annotation.tailrec

--- a/module/ldbc-statement/src/test/scala/ldbc/statement/formatter/NamingTest.scala
+++ b/module/ldbc-statement/src/test/scala/ldbc/statement/formatter/NamingTest.scala
@@ -4,7 +4,7 @@
  * For more information see LICENSE or https://opensource.org/licenses/MIT
  */
 
-package ldbc.query.builder.formatter
+package ldbc.statement.formatter
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -65,28 +65,4 @@ class NamingTest extends AnyFlatSpec, Matchers:
 
   it should "convert snake_case to snake_case" in {
     Naming.toSnake("snake_case") shouldEqual "snake_case"
-  }
-
-  it should "convert kebab-case to kebab_case" in {
-    Naming.toSnake("kebab-case") shouldEqual "kebab_case"
-  }
-
-  "Naming.toKebab" should "convert COLUMN to column" in {
-    Naming.toKebab("COLUMN") shouldEqual "column"
-  }
-
-  it should "convert camelCase to camel-case" in {
-    Naming.toKebab("camelCase") shouldEqual "camel-case"
-  }
-
-  it should "convert PascalCase to pascal-case" in {
-    Naming.toKebab("PascalCase") shouldEqual "pascal-case"
-  }
-
-  it should "convert snake_case to snake-case" in {
-    Naming.toKebab("snake_case") shouldEqual "snake-case"
-  }
-
-  it should "convert kebab-case to kebab-case" in {
-    Naming.toKebab("kebab-case") shouldEqual "kebab-case"
   }

--- a/tests/src/main/scala/ldbc/tests/model/City.scala
+++ b/tests/src/main/scala/ldbc/tests/model/City.scala
@@ -6,8 +6,9 @@
 
 package ldbc.tests.model
 
+import ldbc.statement.formatter.Naming
+
 import ldbc.query.builder.{ Column, Table }
-import ldbc.query.builder.formatter.Naming
 
 import ldbc.schema.{ Table as SchemaTable, * }
 

--- a/tests/src/main/scala/ldbc/tests/model/City.scala
+++ b/tests/src/main/scala/ldbc/tests/model/City.scala
@@ -9,7 +9,7 @@ package ldbc.tests.model
 import ldbc.query.builder.{ Column, Table }
 import ldbc.query.builder.formatter.Naming
 
-import ldbc.schema.Table as SchemaTable
+import ldbc.schema.{ Table as SchemaTable, * }
 
 given Naming = Naming.PASCAL
 
@@ -27,10 +27,22 @@ object City:
 
 class CityTable extends SchemaTable[City]("city"):
 
-  def id:          Column[Int]    = column[Int]("ID")
-  def name:        Column[String] = column[String]("Name")
-  def countryCode: Column[String] = column[String]("CountryCode")
-  def district:    Column[String] = column[String]("District")
-  def population:  Column[Int]    = column[Int]("Population")
+  def id:          Column[Int]    = int("ID").unsigned.autoIncrement
+  def name:        Column[String] = char(35, "Name").default("''")
+  def countryCode: Column[String] = char(3, "CountryCode").default("''")
+  def district:    Column[String] = char(20, "District").default("''")
+  def population:  Column[Int]    = int("Population").default(0)
+
+  override def keys: List[Key] = List(
+    PRIMARY_KEY(id),
+    INDEX_KEY("CountryCode", countryCode),
+    CONSTRAINT(
+      "city_ibfk_1",
+      FOREIGN_KEY(
+        countryCode,
+        REFERENCE(TableQuery[CountryTable])(_.code)
+      )
+    )
+  )
 
   override def * : Column[City] = (id *: name *: countryCode *: district *: population).to[City]

--- a/tests/src/main/scala/ldbc/tests/model/City.scala
+++ b/tests/src/main/scala/ldbc/tests/model/City.scala
@@ -32,7 +32,7 @@ class CityTable extends SchemaTable[City]("city"):
   def name:        Column[String] = char(35, "Name").default("''")
   def countryCode: Column[String] = char(3, "CountryCode").default("''")
   def district:    Column[String] = char(20, "District").default("''")
-  def population:  Column[Int]    = int("Population").default(0)
+  def population:  Column[Int]    = int().default(0)
 
   override def keys: List[Key] = List(
     PRIMARY_KEY(id),

--- a/tests/src/main/scala/ldbc/tests/model/City.scala
+++ b/tests/src/main/scala/ldbc/tests/model/City.scala
@@ -29,9 +29,9 @@ object City:
 class CityTable extends SchemaTable[City]("city"):
 
   def id:          Column[Int]    = int("ID").unsigned.autoIncrement
-  def name:        Column[String] = char(35, "Name").default("''")
-  def countryCode: Column[String] = char(3, "CountryCode").default("''")
-  def district:    Column[String] = char(20, "District").default("''")
+  def name:        Column[String] = char(35).default("''")
+  def countryCode: Column[String] = char(3).default("''")
+  def district:    Column[String] = char(20).default("''")
   def population:  Column[Int]    = int().default(0)
 
   override def keys: List[Key] = List(


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

If a column was to be given a data type or other setting, it had to be passed as an argument.
With this correction, it is now possible to define columns with data type characteristics.

In this method of definition, the column name can be used as the variable name, so it is no longer necessary to pass the column name as an argument.

```diff
class EntityTable extends Table[Entity]("entity"):
-  def c1: Column[Long] = column[Long]("ci", BIGINT, AUTO_INCREMENT)
+  def c1: Column[Long] = bigint().autoIncrement
```

Column names can change their format by implicitly passing Naming.
The default is CamelCase, but to change this to PascalCase, do the following

```scala
class EntityTable extends Table[Entity]("entity"):
  given Naming = Naming.PASCAL

  def c1: Column[Long] = bigint().autoIncrement
```

If you want to change the format of a particular column, you can still define it by passing the column name as an argument.

```scala
class EntityTable extends Table[Entity]("entity"):
  given Naming = Naming.PASCAL

  def c1: Column[Long] = bigint().autoIncrement
  def c2: Column[Long] = bigint("c_2")
```

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
