### PR TITLE
Feature/2025 02 add before after process

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/Connection.scala
@@ -51,8 +51,8 @@ object Connection:
     CapabilitiesFlags.MULTI_FACTOR_AUTHENTICATION
   )
 
-  private def unitBefore[F[_]: Async]: Connection[F] => F[Unit] = _ => Async[F].unit
-  private def unitAfter[F[_]: Async]: (Unit, Connection[F]) => F[Unit] = (_, _) => Async[F].unit
+  private def unitBefore[F[_]: Async]: Connection[F] => F[Unit]         = _ => Async[F].unit
+  private def unitAfter[F[_]: Async]:  (Unit, Connection[F]) => F[Unit] = (_, _) => Async[F].unit
 
   def apply[F[_]: Async: Network: Console: Hashing: UUIDGen](
     host: String,

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/ConnectionTest.scala
@@ -1711,15 +1711,15 @@ class ConnectionTest extends FTestPlatform:
       for
         statement <- connection.createStatement()
         _         <- statement.execute("CREATE DATABASE IF NOT EXISTS connector_before_after_test")
-        _ <- connection.setSchema("connector_before_after_test")
+        _         <- connection.setSchema("connector_before_after_test")
         _ <- statement.execute(
-          """
+               """
             |CREATE TABLE IF NOT EXISTS test (
             |  id INT PRIMARY KEY AUTO_INCREMENT,
             |  name VARCHAR(255) NOT NULL
             |)
             |""".stripMargin
-        )
+             )
       yield 1
 
     def after(length: Int, connection: ldbc.sql.Connection[IO]): IO[Unit] =
@@ -1729,12 +1729,12 @@ class ConnectionTest extends FTestPlatform:
       yield ()
 
     val connection = Connection.withBeforeAfter[IO, Int](
-      host = "127.0.0.1",
-      port = 13306,
-      user = "ldbc",
+      host     = "127.0.0.1",
+      port     = 13306,
+      user     = "ldbc",
       password = Some("password"),
-      before = before,
-      after = after
+      before   = before,
+      after    = after
     )
 
     assertIO(


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Added functionality to connectors to allow processing to be added after the connection to the database is created and before it is destroyed.

This functionality can be achieved by using the withBeforeAfter method for Connection generation.

The second argument of withBeforeAfter specifies the type of the result of processing Before to be passed to After.

```scala 3
Connection.withBeforeAfter[IO, Unit](
  ...,
  before = _ => IO.unit,
  after = (_, _) => IO.unit
)
```

This feature allows users to build connections where common processing takes place.

For example, it is possible to build a table and then delete it.

```scala 3
def before(connection: Connection[IO]): IO[Int] =
  DBIO.sequence(user.schema.create).commit(connection) *>
    IO(user.schema.create.statements.length)

def after(length: Int, connection: Connection[IO]): IO[Unit] =
  DBIO.sequence(user.schema.drop).commit(connection) *>
    IO.println(s"Created $length tables and dropped them")

Connection.withBeforeAfter[IO, Unit](
  ...,
  before,
  after
)
```

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
