### PR TITLE
Add a function to perform a single operation on the DBIO

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Mysql.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Mysql.scala
@@ -27,9 +27,7 @@ import ldbc.dsl.codec.Decoder
  * @tparam F
  *   The effect type
  */
-case class Mysql[F[_]: MonadCancelThrow](statement: String, params: List[Parameter.Dynamic])
-  extends SQL,
-          ParamBinder:
+case class Mysql[F[_]: MonadCancelThrow](statement: String, params: List[Parameter.Dynamic]) extends SQL, ParamBinder:
 
   @targetName("combine")
   override def ++(sql: SQL): Mysql[F] =

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Mysql.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Mysql.scala
@@ -29,7 +29,7 @@ import ldbc.dsl.codec.Decoder
  */
 case class Mysql[F[_]: MonadCancelThrow](statement: String, params: List[Parameter.Dynamic])
   extends SQL,
-          ParamBinder[F]:
+          ParamBinder:
 
   @targetName("combine")
   override def ++(sql: SQL): Mysql[F] =

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
@@ -42,7 +42,7 @@ object Query:
     params:    List[Parameter.Dynamic],
     decoder:   Decoder[T]
   ) extends Query[F, T],
-            ParamBinder[F]:
+            ParamBinder:
 
     given Decoder[T] = decoder
 

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/package.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/package.scala
@@ -22,8 +22,8 @@ import ldbc.dsl.syntax.*
 
 package object dsl:
 
-  private[ldbc] trait ParamBinder[F[_]: MonadThrow]:
-    protected def paramBind(
+  private[ldbc] trait ParamBinder:
+    protected def paramBind[F[_]: MonadThrow](
       prepareStatement: PreparedStatement[F],
       params:           List[Parameter.Dynamic]
     ): F[Unit] =

--- a/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/syntax/package.scala
+++ b/module/ldbc-query-builder/src/main/scala/ldbc/query/builder/syntax/package.scala
@@ -22,7 +22,7 @@ import ldbc.statement.syntax.*
 
 package object syntax:
 
-  private trait SyncSyntax[F[_]: Temporal] extends QuerySyntax[F], CommandSyntax[F], DslSyntax[F], ParamBinder[F]:
+  private trait SyncSyntax[F[_]: Temporal] extends QuerySyntax[F], CommandSyntax[F], DslSyntax[F], ParamBinder:
 
     type TableQuery[T] = ldbc.statement.TableQuery[Table[T], Table.Opt[T]]
     val TableQuery = ldbc.query.builder.TableQuery

--- a/module/ldbc-schema/src/main/scala/ldbc/schema/syntax/package.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/syntax/package.scala
@@ -23,7 +23,7 @@ import ldbc.statement.Schema
 
 package object syntax:
 
-  private trait SyncSyntax[F[_]: Temporal] extends QuerySyntax[F], CommandSyntax[F], DslSyntax[F], ParamBinder[F]:
+  private trait SyncSyntax[F[_]: Temporal] extends QuerySyntax[F], CommandSyntax[F], DslSyntax[F], ParamBinder:
 
     extension [A, B](query: Query[A, B])
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Added support for single processing using DBIO with single function.

```scala 3
DBIO.single[IO]("SELECT 1")
// or
DBIO.single[IO]("SELECT ?", 1)
```

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/394

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
