### PR TITLE
Bugfix/2025 06 Fix jdbc connector

### DIFF
--- a/module/jdbc-connector/src/main/scala/jdbc/connector/ConnectionProvider.scala
+++ b/module/jdbc-connector/src/main/scala/jdbc/connector/ConnectionProvider.scala
@@ -16,7 +16,6 @@ import cats.syntax.all.*
 import cats.Applicative
 
 import cats.effect.*
-import cats.effect.std.Console
 
 import ldbc.sql.{ Connection, Provider }
 import ldbc.sql.logging.{ LogEvent, LogHandler }
@@ -61,7 +60,7 @@ object ConnectionProvider:
     override def use[A](f: Connection[F] => F[A]): F[A] =
       createConnection().use(f)
 
-  class DriverProvider[F[_]: Console](using ev: Async[F]):
+  class DriverProvider[F[_]](using ev: Async[F]):
 
     private def create(
       driver:      String,
@@ -149,11 +148,11 @@ object ConnectionProvider:
    * @param logHandler
    *   Handler for outputting logs of process execution using connections.
    */
-  def fromDataSource[F[_]: Console: Async](
+  def fromDataSource[F[_]: Async](
     dataSource: DataSource,
     connectEC:  ExecutionContext,
     logHandler: Option[LogHandler[F]] = None
-  ): ConnectionProvider[F] = DataSourceProvider(dataSource, connectEC, logHandler)
+  ): ConnectionProvider[F] = DataSourceProvider[F](dataSource, connectEC, logHandler)
 
   /**
    * Construct a `Provider` that wraps an existing `Connection`. Closing the connection is the responsibility of
@@ -164,10 +163,10 @@ object ConnectionProvider:
    * @param logHandler
    *   Handler for outputting logs of process execution using connections.
    */
-  def fromConnection[F[_]: Console: Sync](
+  def fromConnection[F[_]: Sync](
     connection: java.sql.Connection,
     logHandler: Option[LogHandler[F]] = None
-  ): ConnectionProvider[F] = JavaConnectionProvider(connection, logHandler)
+  ): ConnectionProvider[F] = JavaConnectionProvider[F](connection, logHandler)
 
   /** Module of constructors for `Provider` that use the JDBC `DriverManager` to allocate connections. Note that
    * `DriverManager` is unbounded and will happily allocate new connections until server resources are exhausted. It
@@ -175,4 +174,4 @@ object ConnectionProvider:
    * executed on an unbounded cached daemon thread pool by default, so you are also at risk of exhausting system
    * threads. TL;DR this is fine for console apps but don't use it for a web application.
    */
-  def fromDriverManager[F[_]: Console: Async]: DriverProvider[F] = new DriverProvider[F]
+  def fromDriverManager[F[_]: Async]: DriverProvider[F] = new DriverProvider[F]

--- a/module/jdbc-connector/src/main/scala/jdbc/connector/ConnectionProvider.scala
+++ b/module/jdbc-connector/src/main/scala/jdbc/connector/ConnectionProvider.scala
@@ -16,6 +16,7 @@ import cats.syntax.all.*
 import cats.Applicative
 
 import cats.effect.*
+import cats.effect.std.Console
 
 import ldbc.sql.{ Connection, Provider }
 import ldbc.sql.logging.{ LogEvent, LogHandler }
@@ -60,7 +61,7 @@ object ConnectionProvider:
     override def use[A](f: Connection[F] => F[A]): F[A] =
       createConnection().use(f)
 
-  class DriverProvider[F[_]](using ev: Async[F]):
+  class DriverProvider[F[_]: Console](using ev: Async[F]):
 
     private def create(
       driver:      String,
@@ -148,7 +149,7 @@ object ConnectionProvider:
    * @param logHandler
    *   Handler for outputting logs of process execution using connections.
    */
-  def fromDataSource[F[_]: Async](
+  def fromDataSource[F[_]: Console: Async](
     dataSource: DataSource,
     connectEC:  ExecutionContext,
     logHandler: Option[LogHandler[F]] = None
@@ -163,7 +164,7 @@ object ConnectionProvider:
    * @param logHandler
    *   Handler for outputting logs of process execution using connections.
    */
-  def fromConnection[F[_]: Sync](
+  def fromConnection[F[_]: Console: Sync](
     connection: java.sql.Connection,
     logHandler: Option[LogHandler[F]] = None
   ): ConnectionProvider[F] = JavaConnectionProvider[F](connection, logHandler)
@@ -174,4 +175,4 @@ object ConnectionProvider:
    * executed on an unbounded cached daemon thread pool by default, so you are also at risk of exhausting system
    * threads. TL;DR this is fine for console apps but don't use it for a web application.
    */
-  def fromDriverManager[F[_]: Async]: DriverProvider[F] = new DriverProvider[F]
+  def fromDriverManager[F[_]: Console: Async]: DriverProvider[F] = new DriverProvider[F]


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Unexpected compile error when using Scala 3.7.x without explicitly passing type parameters.

<details>
<summary>Error Log</summary>

```
java.lang.AssertionError: assertion failed: trait ConnectionProvider has non-class parent: AppliedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class ldbc)),object sql),Provider),List(TypeRef(ThisType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class jdbc)),object connector),trait ConnectionProvider)),type F)))tal 1s
        at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.traverse$1(SymDenotations.scala:2022)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.computeBaseData(SymDenotations.scala:2027)
        at dotty.tools.dotc.core.SymDenotations$BaseDataImpl.apply(SymDenotations.scala:3021)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.baseData(SymDenotations.scala:1993)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.baseClassSet(SymDenotations.scala:2009)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.derivesFrom(SymDenotations.scala:2035)
        at dotty.tools.dotc.core.SymDenotations$ClassDenotation.isValueClass(SymDenotations.scala:2075)
        at dotty.tools.dotc.core.SymUtils.isDerivedValueClass(SymUtils.scala:85)
        at dotty.tools.dotc.core.TypeErasure$.dotty$tools$dotc$core$TypeErasure$$$erasureDependsOnArgs(TypeErasure.scala:78)
        at dotty.tools.dotc.core.TypeErasure.dotty$tools$dotc$core$TypeErasure$$sigName(TypeErasure.scala:933)
        at dotty.tools.dotc.core.TypeErasure$.sigName(TypeErasure.scala:238)
        at dotty.tools.dotc.core.Signature$.apply(Signature.scala:167)
        at dotty.tools.dotc.core.Types$MethodOrPoly.computeSignature$2(Types.scala:3929)
        at dotty.tools.dotc.core.Types$MethodOrPoly.signature(Types.scala:3954)
        at dotty.tools.dotc.core.Types$MethodOrPoly.computeSignature$2(Types.scala:3925)
        at dotty.tools.dotc.core.Types$MethodOrPoly.signature(Types.scala:3954)
        at dotty.tools.dotc.core.Types$MethodOrPoly.computeSignature$2(Types.scala:3925)
        at dotty.tools.dotc.core.Types$MethodOrPoly.signature(Types.scala:3954)
        at dotty.tools.dotc.core.Denotations$SingleDenotation.signature(Denotations.scala:622)
        at dotty.tools.dotc.core.Denotations$SingleDenotation.signature(Denotations.scala:612)
        at dotty.tools.dotc.core.Types$NamedType.sigFromDenot(Types.scala:2373)
        at dotty.tools.dotc.core.Types$NamedType.computeSignature$1(Types.scala:2344)
        at dotty.tools.dotc.core.Types$NamedType.signature(Types.scala:2349)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:479)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:533)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:519)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:519)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:495)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:519)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:495)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:533)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:519)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTreeUnlessEmpty(TreePickler.scala:356)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleDef(TreePickler.scala:390)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:662)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree$$anonfun$6(TreePickler.scala:571)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:571)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree$$anonfun$3(TreePickler.scala:527)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:527)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTreeUnlessEmpty(TreePickler.scala:356)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleDef(TreePickler.scala:390)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:662)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree$$anonfun$6(TreePickler.scala:571)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:571)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree$$anonfun$3(TreePickler.scala:527)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:527)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTreeUnlessEmpty(TreePickler.scala:356)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleDef(TreePickler.scala:390)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:662)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleStats$$anonfun$2(TreePickler.scala:423)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleStats(TreePickler.scala:423)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:698)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleDef(TreePickler.scala:381)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:664)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleStats$$anonfun$2(TreePickler.scala:423)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleStats(TreePickler.scala:423)
        at dotty.tools.dotc.core.tasty.TreePickler.pickleTree(TreePickler.scala:714)
        at dotty.tools.dotc.core.tasty.TreePickler.pickle$$anonfun$1(TreePickler.scala:938)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.tasty.TreePickler.pickle(TreePickler.scala:936)
        at dotty.tools.dotc.transform.Pickler.run$$anonfun$1$$anonfun$1(Pickler.scala:306)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.transform.Pickler.run$$anonfun$1(Pickler.scala:279)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.transform.Pickler.run(Pickler.scala:278)
        at dotty.tools.dotc.core.Phases$Phase.runOn$$anonfun$1(Phases.scala:383)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:334)
        at dotty.tools.dotc.core.Phases$Phase.runOn(Phases.scala:376)
        at dotty.tools.dotc.transform.Pickler.runPhase$1(Pickler.scala:392)
        at dotty.tools.dotc.transform.Pickler.runOn(Pickler.scala:398)
        at dotty.tools.dotc.Run.runPhases$1$$anonfun$1(Run.scala:368)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1324)
        at dotty.tools.dotc.Run.runPhases$1(Run.scala:361)
        at dotty.tools.dotc.Run.compileUnits$$anonfun$1$$anonfun$2(Run.scala:408)
        at dotty.tools.dotc.Run.compileUnits$$anonfun$1$$anonfun$adapted$1(Run.scala:408)
        at scala.Function0.apply$mcV$sp(Function0.scala:42)
        at dotty.tools.dotc.Run.showProgress(Run.scala:470)
        at dotty.tools.dotc.Run.compileUnits$$anonfun$1(Run.scala:408)
        at dotty.tools.dotc.Run.compileUnits$$anonfun$adapted$1(Run.scala:420)
        at dotty.tools.dotc.util.Stats$.maybeMonitored(Stats.scala:69)
        at dotty.tools.dotc.Run.compileUnits(Run.scala:420)
        at dotty.tools.dotc.Run.compileSources(Run.scala:307)
        at dotty.tools.dotc.Run.compile(Run.scala:292)
        at dotty.tools.dotc.Driver.doCompile(Driver.scala:37)
        at dotty.tools.xsbt.CompilerBridgeDriver.run(CompilerBridgeDriver.java:141)
        at dotty.tools.xsbt.CompilerBridge.run(CompilerBridge.java:22)
        at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:91)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$7(MixedAnalyzingCompiler.scala:196)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:252)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:186)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4$adapted(MixedAnalyzingCompiler.scala:166)
        at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:241)
        at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:166)
        at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:214)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:542)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:542)
        at sbt.internal.inc.Incremental$.$anonfun$apply$3(Incremental.scala:182)
        at sbt.internal.inc.Incremental$.$anonfun$apply$3$adapted(Incremental.scala:180)
        at sbt.internal.inc.Incremental$$anon$2.run(Incremental.scala:458)
        at sbt.internal.inc.IncrementalCommon$CycleState.next(IncrementalCommon.scala:116)
        at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:56)
        at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:52)
        at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:264)
        at sbt.internal.inc.Incremental$.$anonfun$incrementalCompile$8(Incremental.scala:413)
        at sbt.internal.inc.Incremental$.withClassfileManager(Incremental.scala:500)
        at sbt.internal.inc.Incremental$.incrementalCompile(Incremental.scala:400)
        at sbt.internal.inc.Incremental$.apply(Incremental.scala:208)
        at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:542)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:496)
        at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:332)
        at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:433)
        at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:137)
        at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2490)
        at sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2440)
        at sbt.internal.server.BspCompileTask$.$anonfun$compute$1(BspCompileTask.scala:41)
        at sbt.internal.io.Retry$.sbt$internal$io$Retry$$impl(Retry.scala:114)
        at sbt.internal.io.Retry$.io(Retry.scala:102)
        at sbt.internal.io.Retry$.io(Retry.scala:78)
        at sbt.internal.io.Retry$.io(Retry.scala:67)
        at sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:41)
        at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2438)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
        at sbt.std.Transform$$anon$4.work(Transform.scala:69)
        at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
        at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
        at sbt.Execute.work(Execute.scala:292)
        at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
        at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
        at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
no sig for AppliedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class jdbc)),object connector),trait ConnectionProvider),List(TypeParamRef(F))) because of ()
```

</details> 

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
