### PR TITLE
Bug/2025 06 fix codec decode error

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/codec/Codec.scala
@@ -86,9 +86,10 @@ object Codec extends TwiddleSyntax[Codec]:
     }
 
   private def readCatchError[A](offset: Int, func: => A): Either[Decoder.Error, A] =
-    try Option(func) match
-      case Some(result) => Right(result)
-      case None => Left(Decoder.Error(offset, "Result is null", None))
+    try
+      Option(func) match
+        case Some(result) => Right(result)
+        case None         => Left(Decoder.Error(offset, "Result is null", None))
     catch case ex: Throwable => Left(Decoder.Error(offset, ex.getMessage, Some(ex)))
 
   given InvariantSemigroupal[Codec] with


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Errors occur when `null` is returned when using a non-Option type to convert to another type.

Here, a String is returned as null, which causes a NullPointerException to be generated by the split process.

```scala
given Code[List[String]] = Codec[String].imap(_.split(","))(_.mkString("",))
```

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
