### PR TITLE
Feature/2025 06 option method

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/DBIO.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/DBIO.scala
@@ -18,6 +18,8 @@ import ldbc.sql.logging.LogEvent
 
 import ldbc.dsl.codec.Decoder
 import ldbc.dsl.util.FactoryCompat
+import ldbc.dsl.exception.UnexpectedContinuation
+import ldbc.dsl.free.ResultSetIO
 
 /**
  * A trait that represents the execution of a query.
@@ -59,6 +61,11 @@ object DBIO extends ParamBinder:
     decoder:   Decoder[A],
     factory:   FactoryCompat[A, G[A]]
   ) extends DBIOA[G[A]]
+  final case class QueryOption[A](
+    statement: String,
+    params:    List[Parameter.Dynamic],
+    decoder:   Decoder[A]
+  ) extends DBIOA[Option[A]]
   final case class Update(statement: String, params: List[Parameter.Dynamic]) extends DBIOA[Int]
   final case class Returning[A](statement: String, params: List[Parameter.Dynamic], decoder: Decoder[A])
     extends DBIOA[A]
@@ -124,6 +131,8 @@ object DBIO extends ParamBinder:
     factory:   FactoryCompat[A, G[A]]
   ): DBIO[G[A]] =
     liftF(QueryTo(statement, params, decoder, factory))
+  def queryOption[A](statement: String, params: List[Parameter.Dynamic], decoder: Decoder[A]): DBIO[Option[A]] =
+    liftF(QueryOption(statement, params, decoder))
   def update(statement: String, params: List[Parameter.Dynamic]): DBIO[Int] =
     liftF(Update(statement, params))
   def returning[A](statement: String, params: List[Parameter.Dynamic], decoder: Decoder[A]): DBIO[A] =
@@ -150,12 +159,38 @@ object DBIO extends ParamBinder:
                   connection.logHandler.run(LogEvent.ProcessingFailure(statement, params.map(_.value), ex))
                 ) <*
                 connection.logHandler.run(LogEvent.Success(statement, params.map(_.value)))
+
             case QueryTo(statement, params, decoder, factory) =>
               (for
                 prepareStatement <- connection.prepareStatement(statement)
                 resultSet        <- paramBind(prepareStatement, params) >> prepareStatement.executeQuery()
                 result <- ResultSetConsumer.consume(resultSet, statement, factory)(using summon[MonadThrow[F]], decoder)
                 _      <- prepareStatement.close()
+              yield result)
+                .onError(ex =>
+                  connection.logHandler.run(LogEvent.ProcessingFailure(statement, params.map(_.value), ex))
+                ) <*
+                connection.logHandler.run(LogEvent.Success(statement, params.map(_.value)))
+
+            case QueryOption(statement, params, decoder) =>
+              val decoded =
+                for
+                  data <- ResultSetIO.next().flatMap {
+                    case true => decoder.decode(1, statement).map(Option(_))
+                    case false => ResultSetIO.pure(None)
+                  }
+                  next <- ResultSetIO.next()
+                  result <- if next then
+                    ResultSetIO.raiseError(
+                      new UnexpectedContinuation("Expected ResultSet exhaustion, but more rows were available.")
+                    )
+                  else ResultSetIO.pure(data)
+                yield result
+              (for
+                prepareStatement <- connection.prepareStatement(statement)
+                resultSet        <- paramBind(prepareStatement, params) >> prepareStatement.executeQuery()
+                result <- decoded.foldMap(ResultSetIO.interpreter(resultSet))
+                _ <- prepareStatement.close()
               yield result)
                 .onError(ex =>
                   connection.logHandler.run(LogEvent.ProcessingFailure(statement, params.map(_.value), ex))

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/DBIO.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/DBIO.scala
@@ -180,13 +180,13 @@ object DBIO extends ParamBinder:
                             case false => ResultSetIO.pure(None)
                           }
                   next   <- ResultSetIO.next()
-                  result <- if next then
+                  result <- if next then {
                               ResultSetIO.raiseError(
                                 new UnexpectedContinuation(
                                   "Expected ResultSet exhaustion, but more rows were available."
                                 )
                               )
-                            else ResultSetIO.pure(data)
+                            } else ResultSetIO.pure(data)
                 yield result
               (for
                 prepareStatement <- connection.prepareStatement(statement)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
@@ -30,6 +30,13 @@ trait Query[T]:
    * raised. Use the [[to]] method if you want to retrieve individual data.
    */
   def unsafe: DBIO[T]
+  
+  /**
+   * A method to return the data to be retrieved from the database as an Option type. If the data does not exist, None
+   * is returned.
+   * If there is more than one row to be returned, an exception is raised.
+   */
+  def option: DBIO[Option[T]]
 
 object Query:
 
@@ -45,3 +52,6 @@ object Query:
 
     override def unsafe: DBIO[T] =
       DBIO.queryA(statement, params, decoder)
+      
+    override def option: DBIO[Option[T]] =
+      DBIO.queryOption(statement, params, decoder)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
@@ -30,7 +30,7 @@ trait Query[T]:
    * raised. Use the [[to]] method if you want to retrieve individual data.
    */
   def unsafe: DBIO[T]
-  
+
   /**
    * A method to return the data to be retrieved from the database as an Option type. If the data does not exist, None
    * is returned.
@@ -52,6 +52,6 @@ object Query:
 
     override def unsafe: DBIO[T] =
       DBIO.queryA(statement, params, decoder)
-      
+
     override def option: DBIO[Option[T]] =
       DBIO.queryOption(statement, params, decoder)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedContinuation.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedContinuation.scala
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.dsl.exception
+
+class UnexpectedContinuation(
+  message:   String,
+) extends LdbcException(
+  message,
+  None,
+  None
+):
+
+  override def title: String = "Unexpected Continuation Exception"
+  override protected def width = 180

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedContinuation.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedContinuation.scala
@@ -7,12 +7,12 @@
 package ldbc.dsl.exception
 
 class UnexpectedContinuation(
-  message:   String,
+  message: String
 ) extends LdbcException(
-  message,
-  None,
-  None
-):
+    message,
+    None,
+    None
+  ):
 
   override def title: String = "Unexpected Continuation Exception"
   override protected def width = 180

--- a/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -15,6 +15,7 @@ import munit.CatsEffectSuite
 import ldbc.dsl.*
 import ldbc.dsl.codec.auto.generic.toSlowCompile.given
 import ldbc.dsl.codec.Codec
+import ldbc.dsl.exception.UnexpectedContinuation
 
 import ldbc.connector.*
 import ldbc.connector.exception.SQLException
@@ -755,5 +756,31 @@ trait SQLStringContextQueryTest extends CatsEffectSuite:
         yield (a, b, c)).readOnly(conn)
       },
       (Some(MyEnum.A), Some(MyEnum.B), Some(MyEnum.C))
+    )
+  }
+  
+  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+    assertIO(
+      connection.use { conn =>
+        sql"SELECT Name FROM `city` LIMIT 1".query[String].option.readOnly(conn)
+      },
+      Some("Kabul")
+    )
+  }
+
+  test("If option is specified, None is returned when there is no data to be acquired.") {
+    assertIO(
+      connection.use { conn =>
+        sql"SELECT Name FROM `city` WHERE ID = 9999999".query[String].option.readOnly(conn)
+      },
+      None
+    )
+  }
+  
+  test("If option is specified, an exception occurs if there are two or more data to be acquired.") {
+    interceptIO[UnexpectedContinuation](
+      connection.use { conn =>
+        sql"SELECT Name FROM `city`".query[String].option.readOnly(conn)
+      }
     )
   }

--- a/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -758,8 +758,10 @@ trait SQLStringContextQueryTest extends CatsEffectSuite:
       (Some(MyEnum.A), Some(MyEnum.B), Some(MyEnum.C))
     )
   }
-  
-  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+
+  test(
+    "If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case."
+  ) {
     assertIO(
       connection.use { conn =>
         sql"SELECT Name FROM `city` LIMIT 1".query[String].option.readOnly(conn)
@@ -776,7 +778,7 @@ trait SQLStringContextQueryTest extends CatsEffectSuite:
       None
     )
   }
-  
+
   test("If option is specified, an exception occurs if there are two or more data to be acquired.") {
     interceptIO[UnexpectedContinuation](
       connection.use { conn =>

--- a/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
@@ -11,6 +11,7 @@ import cats.effect.*
 import munit.*
 
 import ldbc.dsl.*
+import ldbc.dsl.exception.UnexpectedContinuation
 
 import ldbc.query.builder.*
 
@@ -545,5 +546,31 @@ trait TableQuerySelectConnectionTest extends CatsEffectSuite:
           )
         )
       )
+    )
+  }
+
+  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).limit(1).query.option.readOnly(conn)
+      },
+      Some("Kabul")
+    )
+  }
+
+  test("If option is specified, None is returned when there is no data to be acquired.") {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).where(_.id === 9999999).query.option.readOnly(conn)
+      },
+      None
+    )
+  }
+
+  test("If option is specified, an exception occurs if there are two or more data to be acquired.") {
+    interceptIO[UnexpectedContinuation](
+      connection.use { conn =>
+        city.select(_.name).query.option.readOnly(conn)
+      }
     )
   }

--- a/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
@@ -549,7 +549,9 @@ trait TableQuerySelectConnectionTest extends CatsEffectSuite:
     )
   }
 
-  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+  test(
+    "If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case."
+  ) {
     assertIO(
       connection.use { conn =>
         city.select(_.name).limit(1).query.option.readOnly(conn)

--- a/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
@@ -550,8 +550,9 @@ trait TableSchemaSelectConnectionTest extends CatsEffectSuite:
     )
   }
 
-
-  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+  test(
+    "If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case."
+  ) {
     assertIO(
       connection.use { conn =>
         city.select(_.name).limit(1).query.option.readOnly(conn)

--- a/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
@@ -11,6 +11,7 @@ import cats.effect.*
 import munit.*
 
 import ldbc.dsl.*
+import ldbc.dsl.exception.UnexpectedContinuation
 
 import ldbc.schema.*
 
@@ -546,5 +547,32 @@ trait TableSchemaSelectConnectionTest extends CatsEffectSuite:
           )
         )
       )
+    )
+  }
+
+
+  test("If option is specified, the data to be acquired can be obtained with Some if the data to be acquired is one case.") {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).limit(1).query.option.readOnly(conn)
+      },
+      Some("Kabul")
+    )
+  }
+
+  test("If option is specified, None is returned when there is no data to be acquired.") {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).where(_.id === 9999999).query.option.readOnly(conn)
+      },
+      None
+    )
+  }
+
+  test("If option is specified, an exception occurs if there are two or more data to be acquired.") {
+    interceptIO[UnexpectedContinuation](
+      connection.use { conn =>
+        city.select(_.name).query.option.readOnly(conn)
+      }
     )
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

A method has been added to perform acquisition by wrapping only one case in Option.
If the number of records to be acquired is 1, the record is acquired with Some, and if the number of records is 0, the record is None.
If the number of records retrieved is 2 or more, the option method throws an UnexpectedContinuation exception.

```scala
val result: Option[String] = sql"SELECT Name FROM `city` LIMIT 1".query[String].option.readOnly(conn)

// throw UnexpectedContinuation exception
sql"SELECT Name FROM `city`".query[String].option.readOnly(conn)
```

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
