### PR TITLE
Feature/2025 06 nel method

### DIFF
--- a/docs/src/main/mdoc/en/tutorial/Selecting-Data.md
+++ b/docs/src/main/mdoc/en/tutorial/Selecting-Data.md
@@ -38,7 +38,10 @@ Let's explain this code in detail:
 
 - `sql"SELECT name FROM user"` - Defines the SQL query.
 - `.query[String]` - Maps each row result to a `String` type. This generates a `Query[String]` type.
-- `.to[List]` - Aggregates the results into a `List`. This generates a `DBIO[List[String]]` type. This method can be used with any collection type that implements `FactoryCompat` (such as `List`, `Vector`, `Set`, etc.).
+- `.to[List]` - Aggregates the results into a `List`. This generates a `DBIO[List[String]]` type. This method can be used with any collection type that implements `FactoryCompat` (such as `List`, `Vector`, `Set`, etc.). Similar methods are:
+    - `.unsafe` which returns a single value, raising an exception if there is not exactly one row returned.
+    - `.option` which returns an Option, raising an exception if there is more than one row returned.
+    - `.nel` which returns an NonEmptyList, raising an exception if there are no rows returned.
 - `.readOnly(conn)` - Executes the query using the connection in read-only mode. The return value is `IO[List[String]]`.
 - `.unsafeRunSync()` - Executes the IO monad to get the actual result (`List[String]`).
 - `.foreach(println)` - Outputs each element of the result.

--- a/docs/src/main/mdoc/ja/tutorial/Selecting-Data.md
+++ b/docs/src/main/mdoc/ja/tutorial/Selecting-Data.md
@@ -38,7 +38,10 @@ sql"SELECT name FROM user"
 
 - `sql"SELECT name FROM user"` - SQLクエリを定義します。
 - `.query[String]` - 各行の結果を`String`型にマッピングします。これにより`Query[String]`型が生成されます。
-- `.to[List]` - 結果を`List`に集約します。`DBIO[List[String]]`型が生成されます。このメソッドは`FactoryCompat`を実装する任意のコレクション型（`List`、`Vector`、`Set`など）で使用できます。
+- `.to[List]` - 結果を`List`に集約します。`DBIO[List[String]]`型が生成されます。このメソッドは`FactoryCompat`を実装する任意のコレクション型（`List`、`Vector`、`Set`など）で使用できます。似たような方法として以下があります。
+    - `.unsafe`は単一の値を返し、正確に1行でない場合は例外を発生させる。
+    - `.option`は単一の値をOptionに包んで返し、返される行が複数ある場合は例外を発生させる。
+    - `.nel`は複数の値をNonEmptyListに包んで返し、返される行がない場合は例外を発生させます。
 - `.readOnly(conn)` - コネクションを読み取り専用モードで使用してクエリを実行します。戻り値は`IO[List[String]]`です。
 - `.unsafeRunSync()` - IOモナドを実行して実際の結果（`List[String]`）を取得します。
 - `.foreach(println)` - 結果の各要素を出力します。

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
@@ -7,6 +7,7 @@
 package ldbc.dsl
 
 import cats.*
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 
 import ldbc.dsl.codec.Decoder
@@ -37,6 +38,12 @@ trait Query[T]:
    * If there is more than one row to be returned, an exception is raised.
    */
   def option: DBIO[Option[T]]
+  
+  /**
+   * A method to return the data to be retrieved from the database as a NonEmptyList type.
+   * If there is no data, an exception is raised.
+   */
+  def nel: DBIO[NonEmptyList[T]]
 
 object Query:
 
@@ -55,3 +62,6 @@ object Query:
 
     override def option: DBIO[Option[T]] =
       DBIO.queryOption(statement, params, decoder)
+      
+    override def nel: DBIO[NonEmptyList[T]] =
+      DBIO.queryNel(statement, params, decoder)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/Query.scala
@@ -38,7 +38,7 @@ trait Query[T]:
    * If there is more than one row to be returned, an exception is raised.
    */
   def option: DBIO[Option[T]]
-  
+
   /**
    * A method to return the data to be retrieved from the database as a NonEmptyList type.
    * If there is no data, an exception is raised.
@@ -62,6 +62,6 @@ object Query:
 
     override def option: DBIO[Option[T]] =
       DBIO.queryOption(statement, params, decoder)
-      
+
     override def nel: DBIO[NonEmptyList[T]] =
       DBIO.queryNel(statement, params, decoder)

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/ResultSetConsumer.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/ResultSetConsumer.scala
@@ -7,6 +7,7 @@
 package ldbc.dsl
 
 import cats.*
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 
 import ldbc.sql.ResultSet
@@ -15,6 +16,7 @@ import ldbc.dsl.codec.Decoder
 import ldbc.dsl.free.ResultSetIO
 import ldbc.dsl.free.ResultSetIO.*
 import ldbc.dsl.util.FactoryCompat
+import ldbc.dsl.exception.UnexpectedEnd
 
 /**
  * Trait for generating the specified data type from a ResultSet.
@@ -50,6 +52,18 @@ object ResultSetConsumer:
   ): F[G[T]] =
     given FactoryCompat[T, G[T]] = factoryCompat
     summon[ResultSetConsumer[F, G[T]]].consume(resultSet, statement)
+
+  def consumeToNel[F[_]: MonadThrow, T: Decoder](
+                                                resultSet:     ResultSet[F],
+                                                statement:     String,
+                                              ): F[NonEmptyList[T]] =
+    summon[ResultSetConsumer[F, List[T]]].consume(resultSet, statement)
+      .flatMap { results =>
+        if results.isEmpty then
+          MonadThrow[F].raiseError(new UnexpectedEnd("No results found"))
+        else
+          MonadThrow[F].pure(NonEmptyList.fromListUnsafe(results))
+      }
 
   given [F[_], T](using
     consumer: ResultSetConsumer[F, Option[T]],

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedEnd.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/exception/UnexpectedEnd.scala
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.dsl.exception
+
+class UnexpectedEnd(
+  message: String
+) extends LdbcException(
+    message,
+    None,
+    None
+  ):
+
+  override def title: String = "Unexpected End of ResultSet"

--- a/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/SQLStringContextQueryTest.scala
@@ -799,7 +799,7 @@ trait SQLStringContextQueryTest extends CatsEffectSuite:
       NonEmptyList.of("Kabul", "Qandahar", "Herat", "Mazar-e-Sharif", "Amsterdam")
     )
   }
-  
+
   test("When nel is specified, an exception occurs if there is no data to be acquired.") {
     interceptIO[UnexpectedEnd](
       connection.use { conn =>

--- a/tests/shared/src/test/scala/ldbc/tests/ServerCursorFetchTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/ServerCursorFetchTest.scala
@@ -20,7 +20,7 @@ import ldbc.connector.syntax.*
 class LdbcServerCursorFetchTest extends ServerCursorFetchTest:
 
   // In case of Scala.js, timeout occurs when FetchSize: 1, so it is necessary to extend the time.
-  override def munitIOTimeout: Duration = 60.seconds
+  override def munitIOTimeout: Duration = 80.seconds
 
   override def provider: Provider[IO] =
     ConnectionProvider

--- a/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableQuerySelectConnectionTest.scala
@@ -6,12 +6,14 @@
 
 package ldbc.tests
 
+import cats.data.NonEmptyList
+
 import cats.effect.*
 
 import munit.*
 
 import ldbc.dsl.*
-import ldbc.dsl.exception.UnexpectedContinuation
+import ldbc.dsl.exception.*
 
 import ldbc.query.builder.*
 
@@ -573,6 +575,25 @@ trait TableQuerySelectConnectionTest extends CatsEffectSuite:
     interceptIO[UnexpectedContinuation](
       connection.use { conn =>
         city.select(_.name).query.option.readOnly(conn)
+      }
+    )
+  }
+
+  test(
+    "When nel is specified, if there is one or more data to be retrieved, it can be retrieved with NonEmptyList."
+  ) {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).limit(5).query.nel.readOnly(conn)
+      },
+      NonEmptyList.of("Kabul", "Qandahar", "Herat", "Mazar-e-Sharif", "Amsterdam")
+    )
+  }
+
+  test("When nel is specified, an exception occurs if there is no data to be acquired.") {
+    interceptIO[UnexpectedEnd](
+      connection.use { conn =>
+        city.select(_.name).where(_.id === 9999999).query.nel.readOnly(conn)
       }
     )
   }

--- a/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
@@ -6,12 +6,14 @@
 
 package ldbc.tests
 
+import cats.data.NonEmptyList
+
 import cats.effect.*
 
 import munit.*
 
 import ldbc.dsl.*
-import ldbc.dsl.exception.UnexpectedContinuation
+import ldbc.dsl.exception.*
 
 import ldbc.schema.*
 
@@ -577,3 +579,23 @@ trait TableSchemaSelectConnectionTest extends CatsEffectSuite:
       }
     )
   }
+
+  test(
+    "When nel is specified, if there is one or more data to be retrieved, it can be retrieved with NonEmptyList."
+  ) {
+    assertIO(
+      connection.use { conn =>
+        city.select(_.name).limit(5).query.nel.readOnly(conn)
+      },
+      NonEmptyList.of("Kabul", "Qandahar", "Herat", "Mazar-e-Sharif", "Amsterdam")
+    )
+  }
+
+  test("When nel is specified, an exception occurs if there is no data to be acquired.") {
+    interceptIO[UnexpectedEnd](
+      connection.use { conn =>
+        city.select(_.name).where(_.id === 9999999).query.nel.readOnly(conn)
+      }
+    )
+  }
+

--- a/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/TableSchemaSelectConnectionTest.scala
@@ -598,4 +598,3 @@ trait TableSchemaSelectConnectionTest extends CatsEffectSuite:
       }
     )
   }
-


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

A method has been added to perform acquisition of multiple records wrapped in a NonEmptyList.
If the number of records to be retrieved is 1 or more, the records are retrieved in NonEmptyList, and if 0 records are retrieved, an UnexpectedEnd exception is thrown.

```scala
val result: NonEmptyList[String] = sql"SELECT Name FROM `city`".query[String].nel.readOnly(conn)

// throw UnexpectedEnd exception
sql"SELECT Name FROM `city` WHERE id = 9999999999".query[String].nel.readOnly(conn)
```

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
