### PR TITLE
Enhancement/2025 09 added pool status reporter

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/MySQLConfig.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/MySQLConfig.scala
@@ -370,6 +370,52 @@ trait MySQLConfig:
    */
   def setConnectionTestQuery(query: String): MySQLConfig
 
+  /**
+   * Gets whether pool state logging is enabled.
+   * When enabled, the pool will periodically log its state (connections, active, idle, waiting).
+   * @return true if pool state logging is enabled
+   */
+  def logPoolState: Boolean
+
+  /**
+   * Sets whether to enable periodic logging of pool state.
+   * When enabled, the pool will log statistics at regular intervals to help monitor pool health.
+   * This is useful for debugging connection pool issues and monitoring pool usage patterns.
+   * @param enabled true to enable pool state logging
+   * @return a new MySQLConfig with the updated setting
+   */
+  def setLogPoolState(enabled: Boolean): MySQLConfig
+
+  /**
+   * Gets the interval for pool state logging.
+   * @return the logging interval duration
+   */
+  def poolStateLogInterval: FiniteDuration
+
+  /**
+   * Sets the interval at which pool state is logged.
+   * This controls how often the pool logs its current state when logging is enabled.
+   * Shorter intervals provide more granular monitoring but may produce excessive logs.
+   * @param interval the logging interval (must be > 0)
+   * @return a new MySQLConfig with the updated setting
+   * @throws IllegalArgumentException if interval <= 0
+   */
+  def setPoolStateLogInterval(interval: FiniteDuration): MySQLConfig
+
+  /**
+   * Gets the name of the connection pool for logging purposes.
+   * @return the pool name
+   */
+  def poolName: String
+
+  /**
+   * Sets the name of the connection pool.
+   * This name is used in log messages to identify the pool when multiple pools are in use.
+   * @param name the pool name
+   * @return a new MySQLConfig with the updated setting
+   */
+  def setPoolName(name: String): MySQLConfig
+
 /**
  * Companion object for MySQLConfig providing factory methods.
  */
@@ -406,7 +452,10 @@ object MySQLConfig:
     adaptiveInterval:        FiniteDuration                        = 1.minute,
     aliveBypassWindow:       FiniteDuration                        = 500.milliseconds,
     keepaliveTime:           Option[FiniteDuration]                = Some(2.minutes),
-    connectionTestQuery:     Option[String]                        = None
+    connectionTestQuery:     Option[String]                        = None,
+    logPoolState:            Boolean                               = false,
+    poolStateLogInterval:    FiniteDuration                        = 30.seconds,
+    poolName:                String                                = "ldbc-pool"
   ) extends MySQLConfig:
 
     override def setHost(host:                   String):             MySQLConfig = copy(host = host)
@@ -439,6 +488,9 @@ object MySQLConfig:
     override def setAliveBypassWindow(window:     FiniteDuration): MySQLConfig = copy(aliveBypassWindow = window)
     override def setKeepaliveTime(time:           FiniteDuration): MySQLConfig = copy(keepaliveTime = Some(time))
     override def setConnectionTestQuery(query:    String):         MySQLConfig = copy(connectionTestQuery = Some(query))
+    override def setLogPoolState(enabled:         Boolean):        MySQLConfig = copy(logPoolState = enabled)
+    override def setPoolStateLogInterval(interval: FiniteDuration): MySQLConfig = copy(poolStateLogInterval = interval)
+    override def setPoolName(name:                 String):         MySQLConfig = copy(poolName = name)
 
   /**
    * Creates a default MySQLConfig with standard connection parameters.

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
@@ -15,6 +15,8 @@ import cats.syntax.all.*
 
 import cats.effect.*
 
+import ldbc.connector.exception.SQLException
+
 /**
  * Circuit breaker pattern implementation for connection creation.
  * 
@@ -106,7 +108,7 @@ object CircuitBreaker:
             else
               // Still open, fail fast
               Temporal[F].raiseError(
-                new Exception("Circuit breaker is open")
+                new SQLException("Circuit breaker is open")
               )
           }
 

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/HouseKeeper.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/HouseKeeper.scala
@@ -126,13 +126,13 @@ object HouseKeeper:
           pooled.state.get.flatMap {
             case ConnectionState.Idle =>
               pool.poolLogger.debug(
-                s"Removing expired connection ${pooled.id} (age: ${(now - pooled.createdAt) / 1000}s, maxLifetime: ${config.maxLifetime})"
+                s"Removing expired connection ${ pooled.id } (age: ${ (now - pooled.createdAt) / 1000 }s, maxLifetime: ${ config.maxLifetime })"
               ) >>
                 pool.removeConnection(pooled)
             case ConnectionState.InUse =>
               // Mark for removal after use
               pool.poolLogger.debug(
-                s"Marking in-use connection ${pooled.id} for removal after use (expired)"
+                s"Marking in-use connection ${ pooled.id } for removal after use (expired)"
               ) >>
                 pooled.state.set(ConnectionState.Removed)
             case _ =>

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/HouseKeeper.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/HouseKeeper.scala
@@ -125,10 +125,16 @@ object HouseKeeper:
         expired.traverse_ { pooled =>
           pooled.state.get.flatMap {
             case ConnectionState.Idle =>
-              pool.removeConnection(pooled)
+              pool.poolLogger.debug(
+                s"Removing expired connection ${pooled.id} (age: ${(now - pooled.createdAt) / 1000}s, maxLifetime: ${config.maxLifetime})"
+              ) >>
+                pool.removeConnection(pooled)
             case ConnectionState.InUse =>
               // Mark for removal after use
-              pooled.state.set(ConnectionState.Removed)
+              pool.poolLogger.debug(
+                s"Marking in-use connection ${pooled.id} for removal after use (expired)"
+              ) >>
+                pooled.state.set(ConnectionState.Removed)
             case _ =>
               Temporal[F].unit
           }

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolLogger.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolLogger.scala
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.pool
+
+import cats.*
+
+import cats.effect.*
+import cats.effect.std.Console
+
+/**
+ * A logger for connection pool events and state information.
+ * 
+ * This trait abstracts the logging mechanism for connection pools, allowing
+ * different implementations (console, file, external logging frameworks, etc.)
+ * to be plugged in based on the application's needs.
+ * 
+ * The logger provides different log levels (debug, info, warn, error) to
+ * control the verbosity of output and help with debugging and monitoring
+ * pool behavior.
+ * 
+ * @tparam F the effect type
+ */
+trait PoolLogger[F[_]]:
+
+  /**
+   * Log the current state of the connection pool.
+   * 
+   * This typically includes information like:
+   * - Total connections (current/max)
+   * - Active connections
+   * - Idle connections (current/min)
+   * - Waiting threads
+   * 
+   * @param poolName the name of the pool
+   * @param status the current pool status
+   * @param metrics optional metrics for additional information
+   */
+  def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics] = None): F[Unit]
+
+  /**
+   * Log a debug level message.
+   * 
+   * Debug messages are typically used for detailed information useful
+   * during development or troubleshooting.
+   * 
+   * @param message the message to log
+   */
+  def debug(message: String): F[Unit]
+
+  /**
+   * Log an info level message.
+   * 
+   * Info messages are for general informational events that highlight
+   * the progress of the application at a coarse-grained level.
+   * 
+   * @param message the message to log
+   */
+  def info(message: String): F[Unit]
+
+  /**
+   * Log a warning level message.
+   * 
+   * Warning messages indicate potentially harmful situations that should
+   * be investigated but don't prevent the application from functioning.
+   * 
+   * @param message the message to log
+   */
+  def warn(message: String): F[Unit]
+
+  /**
+   * Log an error level message with an optional exception.
+   * 
+   * Error messages indicate serious problems that have occurred and
+   * typically require immediate attention.
+   * 
+   * @param message the error message
+   * @param error optional exception that caused the error
+   */
+  def error(message: String, error: Option[Throwable] = None): F[Unit]
+
+  /**
+   * Check if debug logging is enabled.
+   * 
+   * This can be used to avoid expensive message construction when
+   * debug logging is disabled.
+   * 
+   * @return true if debug level is enabled
+   */
+  def isDebugEnabled: F[Boolean]
+
+object PoolLogger:
+
+  /**
+   * Creates a PoolLogger that outputs to the console using Cats Effect's Console.
+   * 
+   * This implementation writes all log messages to stdout/stderr based on the log level:
+   * - Debug and Info messages go to stdout
+   * - Warn and Error messages go to stderr
+   * 
+   * The pool state is formatted similar to HikariCP's output:
+   * `[poolName] - stats (total=X/maxSize, idle=Y/minSize, active=Z, waiting=W)`
+   * 
+   * @param logDebug whether debug messages should be logged
+   * @tparam F the effect type (must have Console and Applicative instances)
+   * @return a new console-based PoolLogger
+   */
+  def console[F[_]: Console: Applicative](logDebug: Boolean = false): PoolLogger[F] = new PoolLogger[F]:
+    
+    override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] =
+      val baseStats = s"[$poolName] - stats (total=${status.total}, idle=${status.idle}, active=${status.active}, waiting=${status.waiting})"
+      
+      val fullMessage = metrics match
+        case Some(m) =>
+          val avgAcquisition = m.acquisitionTime.toMillis
+          val timeouts       = m.timeouts
+          val leaks          = m.leaks
+          s"$baseStats [avgAcquisition=${avgAcquisition}ms, timeouts=$timeouts, leaks=$leaks]"
+        case None =>
+          baseStats
+      
+      if logDebug then debug(fullMessage)
+      else Applicative[F].unit
+    
+    override def debug(message: String): F[Unit] =
+      if logDebug then Console[F].println(s"[DEBUG] $message")
+      else Applicative[F].unit
+    
+    override def info(message: String): F[Unit] =
+      Console[F].println(s"[INFO] $message")
+    
+    override def warn(message: String): F[Unit] =
+      Console[F].errorln(s"[WARN] $message")
+    
+    override def error(message: String, error: Option[Throwable]): F[Unit] =
+      val errorMessage = error match
+        case Some(e) => s"$message: ${e.getMessage}"
+        case None    => message
+      Console[F].errorln(s"[ERROR] $errorMessage")
+    
+    override def isDebugEnabled: F[Boolean] =
+      Applicative[F].pure(logDebug)
+
+  /**
+   * Creates a no-op PoolLogger that discards all log messages.
+   * 
+   * This implementation is useful for testing or when logging is not desired.
+   * All methods return immediately without performing any operations.
+   * 
+   * @tparam F the effect type (must have an Applicative instance)
+   * @return a PoolLogger that performs no operations
+   */
+  def noop[F[_]: Applicative]: PoolLogger[F] = new PoolLogger[F]:
+    override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] = 
+      Applicative[F].unit
+    override def debug(message: String): F[Unit] = 
+      Applicative[F].unit
+    override def info(message: String): F[Unit] = 
+      Applicative[F].unit
+    override def warn(message: String): F[Unit] = 
+      Applicative[F].unit
+    override def error(message: String, error: Option[Throwable]): F[Unit] = 
+      Applicative[F].unit
+    override def isDebugEnabled: F[Boolean] = 
+      Applicative[F].pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolLogger.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolLogger.scala
@@ -109,38 +109,39 @@ object PoolLogger:
    * @return a new console-based PoolLogger
    */
   def console[F[_]: Console: Applicative](logDebug: Boolean = false): PoolLogger[F] = new PoolLogger[F]:
-    
+
     override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] =
-      val baseStats = s"[$poolName] - stats (total=${status.total}, idle=${status.idle}, active=${status.active}, waiting=${status.waiting})"
-      
+      val baseStats =
+        s"[$poolName] - stats (total=${ status.total }, idle=${ status.idle }, active=${ status.active }, waiting=${ status.waiting })"
+
       val fullMessage = metrics match
         case Some(m) =>
           val avgAcquisition = m.acquisitionTime.toMillis
           val timeouts       = m.timeouts
           val leaks          = m.leaks
-          s"$baseStats [avgAcquisition=${avgAcquisition}ms, timeouts=$timeouts, leaks=$leaks]"
+          s"$baseStats [avgAcquisition=${ avgAcquisition }ms, timeouts=$timeouts, leaks=$leaks]"
         case None =>
           baseStats
-      
+
       if logDebug then debug(fullMessage)
       else Applicative[F].unit
-    
+
     override def debug(message: String): F[Unit] =
       if logDebug then Console[F].println(s"[DEBUG] $message")
       else Applicative[F].unit
-    
+
     override def info(message: String): F[Unit] =
       Console[F].println(s"[INFO] $message")
-    
+
     override def warn(message: String): F[Unit] =
       Console[F].errorln(s"[WARN] $message")
-    
+
     override def error(message: String, error: Option[Throwable]): F[Unit] =
       val errorMessage = error match
-        case Some(e) => s"$message: ${e.getMessage}"
+        case Some(e) => s"$message: ${ e.getMessage }"
         case None    => message
       Console[F].errorln(s"[ERROR] $errorMessage")
-    
+
     override def isDebugEnabled: F[Boolean] =
       Applicative[F].pure(logDebug)
 
@@ -154,15 +155,15 @@ object PoolLogger:
    * @return a PoolLogger that performs no operations
    */
   def noop[F[_]: Applicative]: PoolLogger[F] = new PoolLogger[F]:
-    override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] = 
+    override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] =
       Applicative[F].unit
-    override def debug(message: String): F[Unit] = 
+    override def debug(message: String): F[Unit] =
       Applicative[F].unit
-    override def info(message: String): F[Unit] = 
+    override def info(message: String): F[Unit] =
       Applicative[F].unit
-    override def warn(message: String): F[Unit] = 
+    override def warn(message: String): F[Unit] =
       Applicative[F].unit
-    override def error(message: String, error: Option[Throwable]): F[Unit] = 
+    override def error(message: String, error: Option[Throwable]): F[Unit] =
       Applicative[F].unit
-    override def isDebugEnabled: F[Boolean] = 
+    override def isDebugEnabled: F[Boolean] =
       Applicative[F].pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolMetricsTracker.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolMetricsTracker.scala
@@ -52,6 +52,11 @@ trait PoolMetricsTracker[F[_]]:
   def recordLeak(): F[Unit]
 
   /**
+   * Record a connection removal.
+   */
+  def recordRemoval(): F[Unit]
+
+  /**
    * Update a gauge metric.
    * 
    * @param name the name of the gauge
@@ -84,6 +89,7 @@ object PoolMetricsTracker:
     def recordCreation(duration:    FiniteDuration):      F[Unit]        = Applicative[F].unit
     def recordTimeout():                                  F[Unit]        = Applicative[F].unit
     def recordLeak():                                     F[Unit]        = Applicative[F].unit
+    def recordRemoval():                                  F[Unit]        = Applicative[F].unit
     def updateGauge(name:           String, value: Long): F[Unit]        = Applicative[F].unit
     def getMetrics:                                       F[PoolMetrics] = Applicative[F].pure(PoolMetrics.empty)
 
@@ -143,6 +149,8 @@ object PoolMetricsTracker:
     override def recordTimeout(): F[Unit] = timeouts.update(_ + 1)
 
     override def recordLeak(): F[Unit] = leaks.update(_ + 1)
+
+    override def recordRemoval(): F[Unit] = removals.update(_ + 1)
 
     override def updateGauge(name: String, value: Long): F[Unit] =
       gauges.update(_.updated(name, value))

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolStatusReporter.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolStatusReporter.scala
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.pool
+
+import scala.concurrent.duration.*
+
+import cats.*
+import cats.syntax.all.*
+
+import cats.effect.*
+import cats.effect.syntax.spawn.*
+
+import fs2.Stream
+
+/**
+ * Background task that periodically reports connection pool status.
+ * 
+ * The PoolStatusReporter runs at configured intervals to log the current state
+ * of the connection pool. This provides visibility into pool health and usage
+ * patterns, similar to HikariCP's pool state logging.
+ * 
+ * Key features:
+ * - Periodic logging of pool statistics
+ * - Includes both basic status (total/active/idle/waiting) and detailed metrics
+ * - Runs as a background fiber that can be cancelled
+ * - Only logs when debug logging is enabled to avoid noise in production
+ * 
+ * @tparam F the effect type
+ */
+trait PoolStatusReporter[F[_]]:
+
+  /**
+   * Start the reporter background task.
+   * 
+   * @param pool the connection pool to monitor
+   * @param poolName the name of the pool for logging
+   * @return a resource that manages the background task lifecycle
+   */
+  def start(pool: PooledDataSource[F], poolName: String): Resource[F, Unit]
+
+object PoolStatusReporter:
+
+  /**
+   * Creates a PoolStatusReporter for asynchronous effect types.
+   * 
+   * The created reporter will log pool status at intervals specified by
+   * `reportInterval`. It uses the provided `poolLogger` for output and
+   * `metricsTracker` to get detailed metrics.
+   * 
+   * The reporter only logs when debug logging is enabled to avoid cluttering
+   * logs in production environments.
+   * 
+   * @param reportInterval the interval between status reports
+   * @param poolLogger the logger to use for output
+   * @param metricsTracker the metrics tracker for detailed statistics
+   * @tparam F the effect type (must have Async and Temporal instances)
+   * @return a new PoolStatusReporter instance
+   */
+  def apply[F[_]: Async](
+    reportInterval: FiniteDuration,
+    poolLogger:     PoolLogger[F],
+    metricsTracker: PoolMetricsTracker[F]
+  ): PoolStatusReporter[F] = new PoolStatusReporter[F]:
+    
+    override def start(pool: PooledDataSource[F], poolName: String): Resource[F, Unit] =
+      val task = Stream
+        .fixedDelay[F](reportInterval)
+        .evalMap { _ =>
+          poolLogger.isDebugEnabled.flatMap { enabled =>
+            if enabled then reportStatus(pool, poolName)
+            else Temporal[F].unit
+          }
+        }
+        .compile
+        .drain
+      
+      Resource
+        .make(task.start)(_.cancel)
+        .void
+    
+    private def reportStatus(pool: PooledDataSource[F], poolName: String): F[Unit] =
+      for
+        status  <- pool.status
+        metrics <- metricsTracker.getMetrics
+        _       <- poolLogger.logPoolState(poolName, status, Some(metrics))
+      yield ()
+
+  /**
+   * Creates a no-op PoolStatusReporter that performs no reporting.
+   * 
+   * This implementation is useful when status reporting is disabled
+   * or not needed. The start method returns immediately without
+   * creating any background tasks.
+   * 
+   * @tparam F the effect type (must have Applicative instance)
+   * @return a PoolStatusReporter that performs no operations
+   */
+  def noop[F[_]: Applicative]: PoolStatusReporter[F] = (pool: PooledDataSource[F], poolName: String) => Resource.pure[F, Unit](())

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolStatusReporter.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PoolStatusReporter.scala
@@ -65,7 +65,7 @@ object PoolStatusReporter:
     poolLogger:     PoolLogger[F],
     metricsTracker: PoolMetricsTracker[F]
   ): PoolStatusReporter[F] = new PoolStatusReporter[F]:
-    
+
     override def start(pool: PooledDataSource[F], poolName: String): Resource[F, Unit] =
       val task = Stream
         .fixedDelay[F](reportInterval)
@@ -77,11 +77,11 @@ object PoolStatusReporter:
         }
         .compile
         .drain
-      
+
       Resource
         .make(task.start)(_.cancel)
         .void
-    
+
     private def reportStatus(pool: PooledDataSource[F], poolName: String): F[Unit] =
       for
         status  <- pool.status
@@ -99,4 +99,5 @@ object PoolStatusReporter:
    * @tparam F the effect type (must have Applicative instance)
    * @return a PoolStatusReporter that performs no operations
    */
-  def noop[F[_]: Applicative]: PoolStatusReporter[F] = (pool: PooledDataSource[F], poolName: String) => Resource.pure[F, Unit](())
+  def noop[F[_]: Applicative]: PoolStatusReporter[F] = (pool: PooledDataSource[F], poolName: String) =>
+    Resource.pure[F, Unit](())

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PooledDataSource.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PooledDataSource.scala
@@ -529,6 +529,7 @@ object PooledDataSource:
                idleConnections = state.idleConnections - pooled.id
              )
            }
+      _ <- metricsTracker.recordRemoval()
     yield ()
 
     /**

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PooledDataSource.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/PooledDataSource.scala
@@ -25,7 +25,6 @@ import ldbc.sql.DatabaseMetaData
 
 import ldbc.connector.*
 
-import ldbc.logging.LogHandler
 import ldbc.DataSource
 
 /**
@@ -186,7 +185,6 @@ object PooledDataSource:
     host:                    String,
     port:                    Int,
     user:                    String,
-    logHandler:              Option[LogHandler[F]]                 = None,
     password:                Option[String]                        = None,
     database:                Option[String]                        = None,
     debug:                   Boolean                               = false,
@@ -724,14 +722,12 @@ object PooledDataSource:
    * properly initialized when acquired and cleanly shut down when released.
    * 
    * @param config the MySQL configuration containing all pool settings
-   * @param logHandler optional handler for logging database operations
    * @param metricsTracker optional tracker for collecting pool metrics (defaults to in-memory tracker)
    * @tparam F the effect type with required type class instances
    * @return a Resource that manages the pooled data source lifecycle
    */
   def fromConfig[F[_]: Async: Network: Console: Hashing: UUIDGen](
     config:         MySQLConfig,
-    logHandler:     Option[LogHandler[F]] = None,
     metricsTracker: Option[PoolMetricsTracker[F]] = None
   ): Resource[F, PooledDataSource[F]] =
     create(config, metricsTracker, UUIDGen[F].randomUUID.map(_.toString))
@@ -749,7 +745,6 @@ object PooledDataSource:
    * to the client. The after hook is called when the connection is returned to the pool.
    * 
    * @param config the MySQL configuration containing all pool settings
-   * @param logHandler optional handler for logging database operations
    * @param metricsTracker optional tracker for collecting pool metrics (defaults to in-memory tracker)
    * @param before optional callback executed before connection use
    * @param after optional callback executed after connection use
@@ -759,7 +754,6 @@ object PooledDataSource:
    */
   def fromConfigWithBeforeAfter[F[_]: Async: Network: Console: Hashing: UUIDGen, A](
     config:         MySQLConfig,
-    logHandler:     Option[LogHandler[F]] = None,
     metricsTracker: Option[PoolMetricsTracker[F]] = None,
     before:         Option[Connection[F] => F[A]] = None,
     after:          Option[(A, Connection[F]) => F[Unit]] = None

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/MySQLDataSourceTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/MySQLDataSourceTest.scala
@@ -30,7 +30,6 @@ class MySQLDataSourceTest extends FTestPlatform:
     assertEquals(dataSource.host, "localhost")
     assertEquals(dataSource.port, 3306)
     assertEquals(dataSource.user, "root")
-    assertEquals(dataSource.logHandler, None)
     assertEquals(dataSource.password, None)
     assertEquals(dataSource.database, None)
     assertEquals(dataSource.debug, false)

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
@@ -64,7 +64,7 @@ class CircuitBreakerTest extends FTestPlatform:
       } yield {
         assert(result.isLeft)
         result.left.foreach { error =>
-          assertEquals(error.getMessage, "Circuit breaker is open")
+          assert(error.getMessage.contains("Circuit breaker is open"))
         }
         assertEquals(state, CircuitBreaker.State.Open)
       }
@@ -121,7 +121,7 @@ class CircuitBreakerTest extends FTestPlatform:
         _          <- IO {
                assert(testResult.isLeft)
                testResult.left.foreach { error =>
-                 assertEquals(error.getMessage, "Circuit breaker is open")
+                 assert(error.getMessage.contains("Circuit breaker is open"))
                }
              }
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/KeepaliveExecutorTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/KeepaliveExecutorTest.scala
@@ -130,9 +130,11 @@ class KeepaliveExecutorTest extends FTestPlatform:
     override def houseKeeper            = None
     override def adaptiveSizer          = None
     override def keepaliveExecutor      = None
+    override def statusReporter         = None
     override def aliveBypassWindow      = 0.seconds
     override def keepaliveTime          = None
     override def connectionTestQuery    = None
+    override def poolLogger             = PoolLogger.noop[F]
     override def circuitBreaker         = ???
     override def getConnection          = ???
     override def status                 = poolStateRef.get.map(s =>

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolLoggerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolLoggerTest.scala
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.pool
+
+import scala.concurrent.duration.*
+
+import cats.effect.*
+
+import munit.CatsEffectSuite
+
+class PoolLoggerTest extends CatsEffectSuite:
+
+  test("PoolLogger.console should log pool state when debug is enabled") {
+    val logger = PoolLogger.console[IO](logDebug = true)
+    
+    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
+    val metrics = PoolMetrics(
+      acquisitionTime   = 100.milliseconds,
+      usageTime         = 500.milliseconds,
+      creationTime      = 200.milliseconds,
+      timeouts          = 2,
+      leaks             = 1,
+      totalAcquisitions = 100,
+      totalReleases     = 98,
+      totalCreations    = 10,
+      totalRemovals     = 0
+    )
+    
+    for
+      _       <- logger.logPoolState("test-pool", status, Some(metrics))
+      enabled <- logger.isDebugEnabled
+    yield assert(enabled)
+  }
+
+  test("PoolLogger.console should not log when debug is disabled") {
+    val logger = PoolLogger.console[IO](logDebug = false)
+    
+    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
+    
+    for
+      _       <- logger.logPoolState("test-pool", status, None)
+      enabled <- logger.isDebugEnabled
+    yield assert(!enabled)
+  }
+
+  test("PoolLogger.noop should not perform any operations") {
+    val logger = PoolLogger.noop[IO]
+    
+    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
+    
+    for
+      _       <- logger.logPoolState("test-pool", status, None)
+      _       <- logger.debug("debug message")
+      _       <- logger.info("info message")
+      _       <- logger.warn("warn message")
+      _       <- logger.error("error message", Some(new Exception("test")))
+      enabled <- logger.isDebugEnabled
+    yield assert(!enabled)
+  }
+
+  test("PoolLogger.console should format pool state correctly") {
+    // This test would need to capture console output to verify formatting
+    // For now, we just ensure it doesn't throw exceptions
+    val logger = PoolLogger.console[IO](logDebug = true)
+    
+    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 2)
+    val metrics = PoolMetrics(
+      acquisitionTime   = 150.milliseconds,
+      usageTime         = 750.milliseconds,
+      creationTime      = 250.milliseconds,
+      timeouts          = 5,
+      leaks             = 0,
+      totalAcquisitions = 1000,
+      totalReleases     = 995,
+      totalCreations    = 15,
+      totalRemovals     = 5
+    )
+    
+    logger.logPoolState("production-pool", status, Some(metrics))
+  }
+
+  test("PoolLogger should handle all log levels") {
+    val logger = PoolLogger.console[IO](logDebug = true)
+    
+    for
+      _ <- logger.debug("Debug message")
+      _ <- logger.info("Info message")
+      _ <- logger.warn("Warning message")
+      _ <- logger.error("Error message")
+      _ <- logger.error("Error with exception", Some(new RuntimeException("Test error")))
+    yield assert(true)
+  }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolLoggerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolLoggerTest.scala
@@ -16,8 +16,8 @@ class PoolLoggerTest extends CatsEffectSuite:
 
   test("PoolLogger.console should log pool state when debug is enabled") {
     val logger = PoolLogger.console[IO](logDebug = true)
-    
-    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
+
+    val status  = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
     val metrics = PoolMetrics(
       acquisitionTime   = 100.milliseconds,
       usageTime         = 500.milliseconds,
@@ -29,7 +29,7 @@ class PoolLoggerTest extends CatsEffectSuite:
       totalCreations    = 10,
       totalRemovals     = 0
     )
-    
+
     for
       _       <- logger.logPoolState("test-pool", status, Some(metrics))
       enabled <- logger.isDebugEnabled
@@ -38,9 +38,9 @@ class PoolLoggerTest extends CatsEffectSuite:
 
   test("PoolLogger.console should not log when debug is disabled") {
     val logger = PoolLogger.console[IO](logDebug = false)
-    
+
     val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
-    
+
     for
       _       <- logger.logPoolState("test-pool", status, None)
       enabled <- logger.isDebugEnabled
@@ -49,9 +49,9 @@ class PoolLoggerTest extends CatsEffectSuite:
 
   test("PoolLogger.noop should not perform any operations") {
     val logger = PoolLogger.noop[IO]
-    
+
     val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 0)
-    
+
     for
       _       <- logger.logPoolState("test-pool", status, None)
       _       <- logger.debug("debug message")
@@ -66,8 +66,8 @@ class PoolLoggerTest extends CatsEffectSuite:
     // This test would need to capture console output to verify formatting
     // For now, we just ensure it doesn't throw exceptions
     val logger = PoolLogger.console[IO](logDebug = true)
-    
-    val status = PoolStatus(total = 10, active = 3, idle = 7, waiting = 2)
+
+    val status  = PoolStatus(total = 10, active = 3, idle = 7, waiting = 2)
     val metrics = PoolMetrics(
       acquisitionTime   = 150.milliseconds,
       usageTime         = 750.milliseconds,
@@ -79,13 +79,13 @@ class PoolLoggerTest extends CatsEffectSuite:
       totalCreations    = 15,
       totalRemovals     = 5
     )
-    
+
     logger.logPoolState("production-pool", status, Some(metrics))
   }
 
   test("PoolLogger should handle all log levels") {
     val logger = PoolLogger.console[IO](logDebug = true)
-    
+
     for
       _ <- logger.debug("Debug message")
       _ <- logger.info("Info message")

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolStatusReporterTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolStatusReporterTest.scala
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.pool
+
+import scala.concurrent.duration.*
+
+import cats.*
+import cats.effect.*
+
+import munit.CatsEffectSuite
+
+import ldbc.connector.Connection
+
+class PoolStatusReporterTest extends CatsEffectSuite:
+
+  class TestPoolLogger[F[_]: Applicative](var logCount: Int = 0) extends PoolLogger[F]:
+    override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): F[Unit] =
+      Applicative[F].pure {
+        logCount += 1
+        ()
+      }
+    override def debug(message: String): F[Unit] = Applicative[F].unit
+    override def info(message: String): F[Unit] = Applicative[F].unit
+    override def warn(message: String): F[Unit] = Applicative[F].unit
+    override def error(message: String, error: Option[Throwable]): F[Unit] = Applicative[F].unit
+    override def isDebugEnabled: F[Boolean] = Applicative[F].pure(true)
+
+  test("PoolStatusReporter should report pool status periodically when enabled") {
+    val testLogger = new TestPoolLogger[IO]()
+    val metricsTracker = PoolMetricsTracker.noop[IO]
+    val reporter = PoolStatusReporter[IO](
+      reportInterval = 100.milliseconds,
+      poolLogger = testLogger,
+      metricsTracker = metricsTracker
+    )
+    
+    // Mock PooledDataSource
+    val pool = new PooledDataSource[IO] {
+      def minConnections = 5
+      def maxConnections = 10
+      def connectionTimeout = 30.seconds
+      def idleTimeout = 10.minutes
+      def maxLifetime = 30.minutes
+      def validationTimeout = 5.seconds
+      def leakDetectionThreshold = None
+      def adaptiveSizing = false
+      def adaptiveInterval = 1.minute
+      def metricsTracker = PoolMetricsTracker.noop[IO]
+      def poolState = ???
+      def idGenerator = IO.pure("test-id")
+      def houseKeeper = None
+      def adaptiveSizer = None
+      def keepaliveExecutor = None
+      def statusReporter = None
+      def aliveBypassWindow = 500.milliseconds
+      def keepaliveTime = None
+      def connectionTestQuery = None
+      def poolLogger = testLogger
+      def getConnection = ???
+      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics = metricsTracker.getMetrics
+      def close = IO.unit
+      def createNewConnection() = ???
+      def circuitBreaker = ???
+      def createNewConnectionForPool() = ???
+      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def removeConnection(pooled: PooledConnection[IO]) = ???
+      def validateConnection(conn: Connection[IO]) = ???
+    }
+    
+    reporter.start(pool, "test-pool").use { _ =>
+      // Wait for at least 2 report cycles
+      IO.sleep(250.milliseconds).map { _ =>
+        assert(testLogger.logCount >= 2, s"Expected at least 2 logs, but got ${testLogger.logCount}")
+      }
+    }
+  }
+
+  test("PoolStatusReporter.noop should not report anything") {
+    val reporter = PoolStatusReporter.noop[IO]
+    val testLogger = new TestPoolLogger[IO]()
+    
+    // Even with a mock pool, noop reporter should not do anything
+    val pool = new PooledDataSource[IO] {
+      def minConnections = 5
+      def maxConnections = 10
+      def connectionTimeout = 30.seconds
+      def idleTimeout = 10.minutes
+      def maxLifetime = 30.minutes
+      def validationTimeout = 5.seconds
+      def leakDetectionThreshold = None
+      def adaptiveSizing = false
+      def adaptiveInterval = 1.minute
+      def metricsTracker = PoolMetricsTracker.noop[IO]
+      def poolState = ???
+      def idGenerator = IO.pure("test-id")
+      def houseKeeper = None
+      def adaptiveSizer = None
+      def keepaliveExecutor = None
+      def statusReporter = None
+      def aliveBypassWindow = 500.milliseconds
+      def keepaliveTime = None
+      def connectionTestQuery = None
+      def poolLogger = testLogger
+      def getConnection = ???
+      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics = ???
+      def close = IO.unit
+      def createNewConnection() = ???
+      def circuitBreaker = ???
+      def createNewConnectionForPool() = ???
+      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def removeConnection(pooled: PooledConnection[IO]) = ???
+      def validateConnection(conn: Connection[IO]) = ???
+    }
+    
+    reporter.start(pool, "test-pool").use { _ =>
+      IO.sleep(200.milliseconds).map { _ =>
+        assertEquals(testLogger.logCount, 0)
+      }
+    }
+  }
+
+  test("PoolStatusReporter should only log when debug is enabled") {
+    val metricsTracker = PoolMetricsTracker.noop[IO]
+    
+    // Logger with debug disabled
+    var logCalledRef = false
+    val debugDisabledLogger = new PoolLogger[IO] {
+      override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): IO[Unit] =
+        IO {
+          logCalledRef = true
+        }
+      override def debug(message: String): IO[Unit] = IO.unit
+      override def info(message: String): IO[Unit] = IO.unit
+      override def warn(message: String): IO[Unit] = IO.unit
+      override def error(message: String, error: Option[Throwable]): IO[Unit] = IO.unit
+      override def isDebugEnabled: IO[Boolean] = IO.pure(false)
+    }
+    
+    val reporter = PoolStatusReporter[IO](
+      reportInterval = 50.milliseconds,
+      poolLogger = debugDisabledLogger,
+      metricsTracker = metricsTracker
+    )
+    
+    // Mock pool
+    val pool = new PooledDataSource[IO] {
+      def minConnections = 5
+      def maxConnections = 10
+      def connectionTimeout = 30.seconds
+      def idleTimeout = 10.minutes
+      def maxLifetime = 30.minutes
+      def validationTimeout = 5.seconds
+      def leakDetectionThreshold = None
+      def adaptiveSizing = false
+      def adaptiveInterval = 1.minute
+      def metricsTracker = PoolMetricsTracker.noop[IO]
+      def poolState = ???
+      def idGenerator = IO.pure("test-id")
+      def houseKeeper = None
+      def adaptiveSizer = None
+      def keepaliveExecutor = None
+      def statusReporter = None
+      def aliveBypassWindow = 500.milliseconds
+      def keepaliveTime = None
+      def connectionTestQuery = None
+      def poolLogger = debugDisabledLogger
+      def getConnection = ???
+      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics = metricsTracker.getMetrics
+      def close = IO.unit
+      def createNewConnection() = ???
+      def circuitBreaker = ???
+      def createNewConnectionForPool() = ???
+      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def removeConnection(pooled: PooledConnection[IO]) = ???
+      def validateConnection(conn: Connection[IO]) = ???
+    }
+    
+    reporter.start(pool, "test-pool").use { _ =>
+      IO.sleep(150.milliseconds).map { _ =>
+        assert(!logCalledRef, "Expected no logs when debug is disabled")
+      }
+    }
+  }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolStatusReporterTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/PoolStatusReporterTest.scala
@@ -9,6 +9,7 @@ package ldbc.connector.pool
 import scala.concurrent.duration.*
 
 import cats.*
+
 import cats.effect.*
 
 import munit.CatsEffectSuite
@@ -23,101 +24,101 @@ class PoolStatusReporterTest extends CatsEffectSuite:
         logCount += 1
         ()
       }
-    override def debug(message: String): F[Unit] = Applicative[F].unit
-    override def info(message: String): F[Unit] = Applicative[F].unit
-    override def warn(message: String): F[Unit] = Applicative[F].unit
-    override def error(message: String, error: Option[Throwable]): F[Unit] = Applicative[F].unit
-    override def isDebugEnabled: F[Boolean] = Applicative[F].pure(true)
+    override def debug(message: String):                           F[Unit]    = Applicative[F].unit
+    override def info(message:  String):                           F[Unit]    = Applicative[F].unit
+    override def warn(message:  String):                           F[Unit]    = Applicative[F].unit
+    override def error(message: String, error: Option[Throwable]): F[Unit]    = Applicative[F].unit
+    override def isDebugEnabled:                                   F[Boolean] = Applicative[F].pure(true)
 
   test("PoolStatusReporter should report pool status periodically when enabled") {
-    val testLogger = new TestPoolLogger[IO]()
+    val testLogger     = new TestPoolLogger[IO]()
     val metricsTracker = PoolMetricsTracker.noop[IO]
-    val reporter = PoolStatusReporter[IO](
+    val reporter       = PoolStatusReporter[IO](
       reportInterval = 100.milliseconds,
-      poolLogger = testLogger,
+      poolLogger     = testLogger,
       metricsTracker = metricsTracker
     )
-    
+
     // Mock PooledDataSource
     val pool = new PooledDataSource[IO] {
-      def minConnections = 5
-      def maxConnections = 10
-      def connectionTimeout = 30.seconds
-      def idleTimeout = 10.minutes
-      def maxLifetime = 30.minutes
-      def validationTimeout = 5.seconds
-      def leakDetectionThreshold = None
-      def adaptiveSizing = false
-      def adaptiveInterval = 1.minute
-      def metricsTracker = PoolMetricsTracker.noop[IO]
-      def poolState = ???
-      def idGenerator = IO.pure("test-id")
-      def houseKeeper = None
-      def adaptiveSizer = None
-      def keepaliveExecutor = None
-      def statusReporter = None
-      def aliveBypassWindow = 500.milliseconds
-      def keepaliveTime = None
-      def connectionTestQuery = None
-      def poolLogger = testLogger
-      def getConnection = ???
-      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
-      def metrics = metricsTracker.getMetrics
-      def close = IO.unit
-      def createNewConnection() = ???
-      def circuitBreaker = ???
+      def minConnections               = 5
+      def maxConnections               = 10
+      def connectionTimeout            = 30.seconds
+      def idleTimeout                  = 10.minutes
+      def maxLifetime                  = 30.minutes
+      def validationTimeout            = 5.seconds
+      def leakDetectionThreshold       = None
+      def adaptiveSizing               = false
+      def adaptiveInterval             = 1.minute
+      def metricsTracker               = PoolMetricsTracker.noop[IO]
+      def poolState                    = ???
+      def idGenerator                  = IO.pure("test-id")
+      def houseKeeper                  = None
+      def adaptiveSizer                = None
+      def keepaliveExecutor            = None
+      def statusReporter               = None
+      def aliveBypassWindow            = 500.milliseconds
+      def keepaliveTime                = None
+      def connectionTestQuery          = None
+      def poolLogger                   = testLogger
+      def getConnection                = ???
+      def status                       = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics                      = metricsTracker.getMetrics
+      def close                        = IO.unit
+      def createNewConnection()        = ???
+      def circuitBreaker               = ???
       def createNewConnectionForPool() = ???
-      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def returnToPool(pooled:     PooledConnection[IO]) = ???
       def removeConnection(pooled: PooledConnection[IO]) = ???
-      def validateConnection(conn: Connection[IO]) = ???
+      def validateConnection(conn: Connection[IO])       = ???
     }
-    
+
     reporter.start(pool, "test-pool").use { _ =>
       // Wait for at least 2 report cycles
       IO.sleep(250.milliseconds).map { _ =>
-        assert(testLogger.logCount >= 2, s"Expected at least 2 logs, but got ${testLogger.logCount}")
+        assert(testLogger.logCount >= 2, s"Expected at least 2 logs, but got ${ testLogger.logCount }")
       }
     }
   }
 
   test("PoolStatusReporter.noop should not report anything") {
-    val reporter = PoolStatusReporter.noop[IO]
+    val reporter   = PoolStatusReporter.noop[IO]
     val testLogger = new TestPoolLogger[IO]()
-    
+
     // Even with a mock pool, noop reporter should not do anything
     val pool = new PooledDataSource[IO] {
-      def minConnections = 5
-      def maxConnections = 10
-      def connectionTimeout = 30.seconds
-      def idleTimeout = 10.minutes
-      def maxLifetime = 30.minutes
-      def validationTimeout = 5.seconds
-      def leakDetectionThreshold = None
-      def adaptiveSizing = false
-      def adaptiveInterval = 1.minute
-      def metricsTracker = PoolMetricsTracker.noop[IO]
-      def poolState = ???
-      def idGenerator = IO.pure("test-id")
-      def houseKeeper = None
-      def adaptiveSizer = None
-      def keepaliveExecutor = None
-      def statusReporter = None
-      def aliveBypassWindow = 500.milliseconds
-      def keepaliveTime = None
-      def connectionTestQuery = None
-      def poolLogger = testLogger
-      def getConnection = ???
-      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
-      def metrics = ???
-      def close = IO.unit
-      def createNewConnection() = ???
-      def circuitBreaker = ???
+      def minConnections               = 5
+      def maxConnections               = 10
+      def connectionTimeout            = 30.seconds
+      def idleTimeout                  = 10.minutes
+      def maxLifetime                  = 30.minutes
+      def validationTimeout            = 5.seconds
+      def leakDetectionThreshold       = None
+      def adaptiveSizing               = false
+      def adaptiveInterval             = 1.minute
+      def metricsTracker               = PoolMetricsTracker.noop[IO]
+      def poolState                    = ???
+      def idGenerator                  = IO.pure("test-id")
+      def houseKeeper                  = None
+      def adaptiveSizer                = None
+      def keepaliveExecutor            = None
+      def statusReporter               = None
+      def aliveBypassWindow            = 500.milliseconds
+      def keepaliveTime                = None
+      def connectionTestQuery          = None
+      def poolLogger                   = testLogger
+      def getConnection                = ???
+      def status                       = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics                      = ???
+      def close                        = IO.unit
+      def createNewConnection()        = ???
+      def circuitBreaker               = ???
       def createNewConnectionForPool() = ???
-      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def returnToPool(pooled:     PooledConnection[IO]) = ???
       def removeConnection(pooled: PooledConnection[IO]) = ???
-      def validateConnection(conn: Connection[IO]) = ???
+      def validateConnection(conn: Connection[IO])       = ???
     }
-    
+
     reporter.start(pool, "test-pool").use { _ =>
       IO.sleep(200.milliseconds).map { _ =>
         assertEquals(testLogger.logCount, 0)
@@ -127,61 +128,61 @@ class PoolStatusReporterTest extends CatsEffectSuite:
 
   test("PoolStatusReporter should only log when debug is enabled") {
     val metricsTracker = PoolMetricsTracker.noop[IO]
-    
+
     // Logger with debug disabled
-    var logCalledRef = false
+    var logCalledRef        = false
     val debugDisabledLogger = new PoolLogger[IO] {
       override def logPoolState(poolName: String, status: PoolStatus, metrics: Option[PoolMetrics]): IO[Unit] =
         IO {
           logCalledRef = true
         }
-      override def debug(message: String): IO[Unit] = IO.unit
-      override def info(message: String): IO[Unit] = IO.unit
-      override def warn(message: String): IO[Unit] = IO.unit
-      override def error(message: String, error: Option[Throwable]): IO[Unit] = IO.unit
-      override def isDebugEnabled: IO[Boolean] = IO.pure(false)
+      override def debug(message: String):                           IO[Unit]    = IO.unit
+      override def info(message:  String):                           IO[Unit]    = IO.unit
+      override def warn(message:  String):                           IO[Unit]    = IO.unit
+      override def error(message: String, error: Option[Throwable]): IO[Unit]    = IO.unit
+      override def isDebugEnabled:                                   IO[Boolean] = IO.pure(false)
     }
-    
+
     val reporter = PoolStatusReporter[IO](
       reportInterval = 50.milliseconds,
-      poolLogger = debugDisabledLogger,
+      poolLogger     = debugDisabledLogger,
       metricsTracker = metricsTracker
     )
-    
+
     // Mock pool
     val pool = new PooledDataSource[IO] {
-      def minConnections = 5
-      def maxConnections = 10
-      def connectionTimeout = 30.seconds
-      def idleTimeout = 10.minutes
-      def maxLifetime = 30.minutes
-      def validationTimeout = 5.seconds
-      def leakDetectionThreshold = None
-      def adaptiveSizing = false
-      def adaptiveInterval = 1.minute
-      def metricsTracker = PoolMetricsTracker.noop[IO]
-      def poolState = ???
-      def idGenerator = IO.pure("test-id")
-      def houseKeeper = None
-      def adaptiveSizer = None
-      def keepaliveExecutor = None
-      def statusReporter = None
-      def aliveBypassWindow = 500.milliseconds
-      def keepaliveTime = None
-      def connectionTestQuery = None
-      def poolLogger = debugDisabledLogger
-      def getConnection = ???
-      def status = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
-      def metrics = metricsTracker.getMetrics
-      def close = IO.unit
-      def createNewConnection() = ???
-      def circuitBreaker = ???
+      def minConnections               = 5
+      def maxConnections               = 10
+      def connectionTimeout            = 30.seconds
+      def idleTimeout                  = 10.minutes
+      def maxLifetime                  = 30.minutes
+      def validationTimeout            = 5.seconds
+      def leakDetectionThreshold       = None
+      def adaptiveSizing               = false
+      def adaptiveInterval             = 1.minute
+      def metricsTracker               = PoolMetricsTracker.noop[IO]
+      def poolState                    = ???
+      def idGenerator                  = IO.pure("test-id")
+      def houseKeeper                  = None
+      def adaptiveSizer                = None
+      def keepaliveExecutor            = None
+      def statusReporter               = None
+      def aliveBypassWindow            = 500.milliseconds
+      def keepaliveTime                = None
+      def connectionTestQuery          = None
+      def poolLogger                   = debugDisabledLogger
+      def getConnection                = ???
+      def status                       = IO.pure(PoolStatus(total = 10, active = 3, idle = 7, waiting = 0))
+      def metrics                      = metricsTracker.getMetrics
+      def close                        = IO.unit
+      def createNewConnection()        = ???
+      def circuitBreaker               = ???
       def createNewConnectionForPool() = ???
-      def returnToPool(pooled: PooledConnection[IO]) = ???
+      def returnToPool(pooled:     PooledConnection[IO]) = ???
       def removeConnection(pooled: PooledConnection[IO]) = ???
-      def validateConnection(conn: Connection[IO]) = ???
+      def validateConnection(conn: Connection[IO])       = ???
     }
-    
+
     reporter.start(pool, "test-pool").use { _ =>
       IO.sleep(150.milliseconds).map { _ =>
         assert(!logCalledRef, "Expected no logs when debug is disabled")

--- a/tests/js/src/test/scala/ldbc/tests/ConnectionPoolDslTest.scala
+++ b/tests/js/src/test/scala/ldbc/tests/ConnectionPoolDslTest.scala
@@ -161,7 +161,7 @@ trait ConnectionPoolDslTest extends CatsEffectSuite:
     for
       tracker <- metricsTracker
       pool    <- PooledDataSource
-                .fromConfig[IO](config.setMinConnections(1).setMaxConnections(3), None, Some(tracker))
+                .fromConfig[IO](config.setMinConnections(1).setMaxConnections(3), Some(tracker))
                 .allocated
                 .map(_._1)
 

--- a/tests/jvm/src/test/scala/ldbc/tests/ConnectionPoolDslTest.scala
+++ b/tests/jvm/src/test/scala/ldbc/tests/ConnectionPoolDslTest.scala
@@ -163,7 +163,7 @@ trait ConnectionPoolDslTest extends CatsEffectSuite:
     for
       tracker <- metricsTracker
       pool    <- PooledDataSource
-                .fromConfig[IO](config.setMinConnections(1).setMaxConnections(3), None, Some(tracker))
+                .fromConfig[IO](config.setMinConnections(1).setMaxConnections(3), Some(tracker))
                 .allocated
                 .map(_._1)
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

### Newly Added Files

1. `PoolLogger.scala`
  - Trait for logging connection pool events and status
  - `PoolLogger.console[F]` - Implementation using Cats Effect's Console
  - `PoolLogger.noop[F]` - No-op implementation for testing

2. `PoolStatusReporter.scala`
  - A background task that periodically reports pool status at a configured interval
  - Outputs only when debug logs are enabled
  - Uses fs2's Stream for periodic execution

### Modifying Existing Files

#### 1. `MySQLConfig.scala`
  Add the following configuration items:
  - `logPoolState: Boolean` - Enable/disable pool state logging (Default: false)
  - `poolStateLogInterval: FiniteDuration` - Log output interval (Default: 30 seconds)
  - `poolName: String` - Pool identifier (Default: "ldbc-pool")

2. `PooledDataSource.scala`
  - Added `PoolLogger` field
  - Integrated `PoolStatusReporter`
  - Launched StatusReporter as a background task

3. `HouseKeeper.scala`
  - Removed pool status log output from HouseKeeper to avoid duplication
  - Consolidated to PoolStatusReporter

## How to Use
Usage Instructions

```scala
  // Enable pool state log
  val config = MySQLConfig.default
    .setHost("localhost")
    .setPort(3306)
    .setUser("user")
    .setPassword("password")
    .setDatabase("test")
    .setLogPoolState(true)                    // Enable log output
    .setPoolStateLogInterval(30.seconds)      // Output every 30 seconds
    .setPoolName("main-pool")                 // Set pool name

  PooledDataSource.fromConfig[IO](config).use { pool =>
    // The pool automatically logs its status.
    // example: [DEBUG] [main-pool] - stats (total=10, idle=7, active=3, waiting=0) [avgAcquisition=15ms, timeouts=0, leaks=0]
  }

  Example of Using Multiple Pools

  // Read pool
  val readConfig = MySQLConfig.default
    .setPoolName("read-pool")
    .setLogPoolState(true)
    // Other settings...

  // Write pool 
  val writeConfig = MySQLConfig.default
    .setPoolName("write-pool")
    .setLogPoolState(true)
    // Other settings...
```

**Output Format**

Outputs the pool status in the same format as HikariCP:

```
[DEBUG] [pool-name] - stats (total=10, idle=7, active=3, waiting=0) [avgAcquisition=15ms, timeouts=0, leaks=0]
```

- total: Total number of connections in the pool
- idle: Number of idle connections
- active: Number of connections in use
- waiting: Number of requests waiting to connect
- avgAcquisition: Average connection acquisition time
- timeouts: Number of timeouts
- leaks: Number of leaks detected

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
