### PR TITLE
Feature/2026 04 when query helper

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
@@ -102,6 +102,16 @@ trait HelperFunctionsSyntax extends StringContextSyntax:
   def orFallbackFalse[M[_]: Foldable](ss: M[SQL]): Mysql =
     orOpt(ss).getOrElse(sql"FALSE")
 
+  /** Returns `frag` if `cond` is true, otherwise the empty sql.
+   * {{{
+   *   sql"SELECT * FROM user" ++ when(limit > 0)(sql" LIMIT $limit")
+   *   // if limit > 0: SELECT * FROM user LIMIT ?
+   *   // if limit <= 0: SELECT * FROM user
+   * }}}
+   */
+  def when(cond: Boolean)(frag: Mysql): Mysql =
+    if cond then frag else Mysql("", Nil)
+
   /** Returns `WHERE s1 AND s2 AND ... sn`. */
   def whereAnd(s1: SQL, ss: SQL*): Mysql =
     whereAnd(NonEmptyList(s1, ss.toList))

--- a/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
+++ b/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
@@ -144,6 +144,30 @@ class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSynt
     assertEquals(sql.statement, "((a = 1) OR (b = 2))")
   }
 
+  test("when with true condition should return the fragment") {
+    val limit = 20
+    val sql   = when(limit > 0)(sql" LIMIT $limit")
+    assertEquals(sql.statement, " LIMIT ?")
+    assertEquals(sql.params.size, 1)
+  }
+
+  test("when with false condition should return empty sql") {
+    val limit = 0
+    val sql   = when(limit > 0)(sql" LIMIT $limit")
+    assertEquals(sql.statement, "")
+    assertEquals(sql.params.size, 0)
+  }
+
+  test("when can be chained with ++ for multiple optional clauses") {
+    val limit  = 20
+    val offset = 0
+    val query  = sql"SELECT * FROM user" ++
+      when(limit > 0)(sql" LIMIT $limit") ++
+      when(offset > 0)(sql" OFFSET $offset")
+    assertEquals(query.statement, "SELECT * FROM user LIMIT ?")
+    assertEquals(query.params.size, 1)
+  }
+
   test("whereAnd with NonEmptyList should create WHERE AND clause") {
     val sql = whereAnd(NonEmptyList.of(sql"active = true", sql"age > 18"))
     assertEquals(sql.statement, "WHERE (active = true) AND (age > 18)")


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

We have added the `when()` helper function, which allows you to concisely write code that dynamically adds SQL fragments based on Boolean conditions using the `sql"..."` interpolator.

When dynamically constructing SQL statements based on multiple conditions, it used to be necessary to write conditional statements by hand each time, as shown below.

```scala
val limitClause  = if limit > 0  then sql" LIMIT $limit"  else sql""
val offsetClause = if offset > 0 then sql" OFFSET $offset" else sql""
val query = sql"SELECT * FROM user WHERE active = $isActive" ++ limitClause ++ offsetClause
```

Added `when(cond: Boolean)(frag: Mysql): Mysql`. Returns `frag` if `cond` is `true`, and returns an empty SQL fragment if `cond` is `false`.

```scala
val query = sql"SELECT * FROM user WHERE active = $isActive" ++
  when(limit > 0)(sql" LIMIT $limit") ++
  when(offset > 0)(sql" OFFSET $offset")
// When limit=20 and offset=0 → SELECT * FROM user WHERE active = ? LIMIT ?
// When limit=0 and offset=0 → SELECT * FROM user WHERE active = ?
```

You can use the `++` operator to chain multiple conditional statements together.

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
