### PR TITLE
Feature/2026 04 pagenate query helper

### DIFF
--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
@@ -24,8 +24,27 @@ trait HelperFunctionsSyntax extends StringContextSyntax:
    *   sql"SELECT * FROM $table WHERE id = ${1L}"
    *   // SELECT * FROM table WHERE id = ?
    * }}}
+   *
+   * @note This is not safe for user input. Use [[ident]] instead.
    */
+  @deprecated("Use ident() for safe identifier escaping with backticks.", "0.7.x")
   def sc(value: String): Parameter.Static = Parameter.Static(value)
+
+  /**
+   * Function for safely embedding a SQL identifier (table name, column name, etc.) by escaping it
+   * with backticks. Backtick characters in the name are escaped, and NULL characters are removed.
+   * Safe to use with user input, unlike [[sc]].
+   * {{{
+   *   sql"SELECT * FROM ${ident("users")}"
+   *   // SELECT * FROM `users`
+   *
+   *   sql"SELECT ${ident("created_at")} FROM ${ident(tableName)}"
+   *   // SELECT `created_at` FROM `user_table`
+   * }}}
+   */
+  def ident(name: String): Parameter.Static =
+    val escaped = name.replace("`", "\\`").replace("\u0000", "")
+    Parameter.Static(s"`$escaped`")
 
   // The following helper functions for building SQL models are rewritten from doobie fragments for ldbc SQL models.
   // see: https://github.com/tpolecat/doobie/blob/main/modules/core/src/main/scala/doobie/util/fragments.scala

--- a/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
+++ b/module/ldbc-dsl/src/main/scala/ldbc/dsl/syntax/HelperFunctionsSyntax.scala
@@ -185,6 +185,19 @@ trait HelperFunctionsSyntax extends StringContextSyntax:
   def orderByOpt(s1: Option[SQL], s2: Option[SQL], ss: Option[SQL]*): Mysql =
     orderByOpt((s1 :: s2 :: ss.toList).flatten)
 
+  /** Returns `LIMIT limit OFFSET offset`, or `LIMIT limit` if offset is 0.
+   * {{{
+   *   sql"SELECT * FROM user " ++ paginate(20, 40)
+   *   // SELECT * FROM user LIMIT ? OFFSET ?
+   *
+   *   sql"SELECT * FROM user " ++ paginate(20)
+   *   // SELECT * FROM user LIMIT ?
+   * }}}
+   */
+  def paginate(limit: Int, offset: Int = 0): Mysql =
+    if offset > 0 then sql"LIMIT $limit OFFSET $offset"
+    else sql"LIMIT $limit"
+
   implicit def toDBIO[A](dbio: DBIO[A]): DBIO.Ops[A] = new DBIO.Ops(dbio)
 
   implicit val syncDBIO: Sync[DBIO] = DBIO.syncDBIO

--- a/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
+++ b/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
@@ -223,6 +223,33 @@ class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSynt
     assertEquals(sql.statement, "ORDER BY name,id")
   }
 
+  test("paginate with limit only should create LIMIT clause") {
+    val sql = paginate(20)
+    assertEquals(sql.statement, "LIMIT ?")
+    assertEquals(sql.params.size, 1)
+  }
+
+  test("paginate with limit and offset should create LIMIT OFFSET clause") {
+    val sql = paginate(20, 40)
+    assertEquals(sql.statement, "LIMIT ? OFFSET ?")
+    assertEquals(sql.params.size, 2)
+  }
+
+  test("paginate with offset 0 should omit OFFSET") {
+    val sql = paginate(20, 0)
+    assertEquals(sql.statement, "LIMIT ?")
+    assertEquals(sql.params.size, 1)
+  }
+
+  test("paginate can be chained with orderBy") {
+    val query = sql"SELECT * FROM user " ++
+      orderBy(sql"`created_at` DESC") ++
+      sql" " ++
+      paginate(20, 40)
+    assertEquals(query.statement, "SELECT * FROM user ORDER BY `created_at` DESC LIMIT ? OFFSET ?")
+    assertEquals(query.params.size, 2)
+  }
+
   test("Complex query composition using multiple helper functions") {
     val table      = sc("users")
     val conditions = List(

--- a/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
+++ b/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
@@ -16,16 +16,40 @@ import ldbc.dsl.codec.{ Codec, Encoder }
 
 class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSyntax:
 
+  @annotation.nowarn("msg=deprecated")
+  private def scLegacy(value: String): Parameter.Static = sc(value)
+
   test("sc function should create static parameter") {
-    val table = sc("users")
+    val table = scLegacy("users")
     assertEquals(table, Parameter.Static("users"))
   }
 
   test("sc function should be usable in SQL interpolation") {
-    val table = sc("users")
+    val table = scLegacy("users")
     val sql   = sql"SELECT * FROM $table WHERE id = ${ 1L }"
     assertEquals(sql.statement, "SELECT * FROM users WHERE id = ?")
     assertEquals(sql.params.size, 1)
+  }
+
+  test("ident function should wrap identifier with backticks") {
+    val col = ident("created_at")
+    assertEquals(col, Parameter.Static("`created_at`"))
+  }
+
+  test("ident function should be usable in SQL interpolation") {
+    val query = sql"SELECT ${ident("name")} FROM ${ident("users")} WHERE id = ${ 1L }"
+    assertEquals(query.statement, "SELECT `name` FROM `users` WHERE id = ?")
+    assertEquals(query.params.size, 1)
+  }
+
+  test("ident function should escape backtick characters") {
+    val col = ident("bad`name")
+    assertEquals(col, Parameter.Static("`bad\\`name`"))
+  }
+
+  test("ident function should remove NULL characters") {
+    val col = ident("bad\u0000name")
+    assertEquals(col, Parameter.Static("`badname`"))
   }
 
   test("values function with List should create VALUES clause") {
@@ -251,7 +275,7 @@ class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSynt
   }
 
   test("Complex query composition using multiple helper functions") {
-    val table      = sc("users")
+    val table      = ident("users")
     val conditions = List(
       Some(sql"active = ${ true }"),
       Some(sql"age >= ${ 18 }"),
@@ -265,7 +289,7 @@ class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSynt
 
     assertEquals(
       query.statement,
-      "SELECT * FROM users WHERE (active = ?) AND (age >= ?) ORDER BY created_at DESC"
+      "SELECT * FROM `users` WHERE (active = ?) AND (age >= ?) ORDER BY created_at DESC"
     )
     assertEquals(query.params.size, 2)
   }

--- a/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
+++ b/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/HelperFunctionsSyntaxTest.scala
@@ -37,7 +37,7 @@ class HelperFunctionsSyntaxTest extends CatsEffectSuite with HelperFunctionsSynt
   }
 
   test("ident function should be usable in SQL interpolation") {
-    val query = sql"SELECT ${ident("name")} FROM ${ident("users")} WHERE id = ${ 1L }"
+    val query = sql"SELECT ${ ident("name") } FROM ${ ident("users") } WHERE id = ${ 1L }"
     assertEquals(query.statement, "SELECT `name` FROM `users` WHERE id = ?")
     assertEquals(query.params.size, 1)
   }

--- a/tests/shared/src/test/scala/ldbc/tests/SQLStringContextUpdateTest.scala
+++ b/tests/shared/src/test/scala/ldbc/tests/SQLStringContextUpdateTest.scala
@@ -43,8 +43,8 @@ trait SQLStringContextUpdateTest extends CatsEffectSuite:
     .fixture
 
   final val table = prefix match
-    case "jdbc" => sc("`jdbc_sql_string_context_table`")
-    case "ldbc" => sc("`ldbc_sql_string_context_table`")
+    case "jdbc" => ident("jdbc_sql_string_context_table")
+    case "ldbc" => ident("ldbc_sql_string_context_table")
 
   override def munitFixtures = List(connectionFixture)
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

We have added the `paginate()` helper function, which allows you to concisely write LIMIT and OFFSET clauses using the `sql"..."` interpolator.

With queries that use pagination, I had to manually specify LIMIT and OFFSET every time.

```scala
sql"SELECT * FROM user ORDER BY created_at DESC LIMIT $limit OFFSET $offset"
```

Added `paginate(limit: Int, offset: Int = 0): Mysql`. When `offset` is `0`, the `OFFSET` clause is omitted.

```scala
// LIMIT only
sql"SELECT * FROM user " ++ paginate(20)
// → SELECT * FROM user LIMIT ?

// LIMIT + OFFSET
sql"SELECT * FROM user " ++ paginate(20, 40)
// → SELECT * FROM user LIMIT ? OFFSET ?

// in combination with orderBy
sql"SELECT * FROM user " ++
  orderBy(sql"`created_at` DESC") ++
  sql" " ++
  paginate(20, 40)
// → SELECT * FROM user ORDER BY `created_at` DESC LIMIT ? OFFSET ?
```

---

As a safe alternative to `sc()`, we have added the `ident()` helper function, which escapes SQL identifiers (such as table names and column names) using backticks.

Since `sc()` embeds user input directly into an SQL string without escaping it, there was a risk of SQL injection. Although the documentation explicitly stated that it was unsafe, there was no safe alternative available.

```scala
val tableName = request.getParameter("table") // User input
sql"SELECT * FROM ${sc(tableName)}"           // Danger
```

Added `ident(name: String): Parameter.Static`. This method wraps the identifier in backticks, escapes the backtick characters, and removes any null characters.

```scala
sql"SELECT ${ident("name")} FROM ${ident("users")} WHERE id = $id"
// → SELECT `name` FROM `users` WHERE id = ?

// Escape backticks if they are present
ident("bad`name") // → `bad\`name`

// Remove null characters
ident("bad\u0000name") // → `badname`
```

We have also added the `@deprecated` annotation to `sc()` to trigger a compile-time warning encouraging the transition to `ident()`.

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
