### PR TITLE
Bugfix/2026 05 issues 711

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/SharedPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/SharedPreparedStatement.scala
@@ -116,6 +116,6 @@ private[ldbc] trait SharedPreparedStatement[F[_]: Sync] extends PreparedStatemen
     original.trim.toLowerCase match
       case q if q.startsWith("insert") =>
         val bindQuery = buildQuery(original, params)
-        bindQuery.split("VALUES").last
+        bindQuery.split("(?i)VALUES").last
       case q if q.startsWith("update") || q.startsWith("delete") => buildQuery(original, params)
       case _ => throw new IllegalArgumentException("The batch query must be an INSERT, UPDATE, or DELETE statement.")

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
@@ -244,6 +244,29 @@ class SharedPreparedStatementTest extends SharedPreparedStatement[IO], FTestPlat
     } yield ()
   }
 
+  test("Bug #711: buildBatchQuery should handle INSERT with lowercase 'values' keyword") {
+    for {
+      _      <- resetParams
+      _      <- setInt(1, 100)
+      _      <- setString(2, "John")
+      result <- params.get.map(p => buildBatchQuery("INSERT INTO users (id, name) values (?, ?)", p))
+      // split("VALUES") does not match lowercase "values", so .last returns the entire query string
+      // This assertion FAILS with the current (buggy) implementation
+      _      <- IO(assertEquals(result, " (100, 'John')"))
+    } yield ()
+  }
+
+  test("Bug #711: buildBatchQuery should handle INSERT with mixed-case 'Values' keyword") {
+    for {
+      _      <- resetParams
+      _      <- setInt(1, 100)
+      _      <- setString(2, "John")
+      result <- params.get.map(p => buildBatchQuery("INSERT INTO users (id, name) Values (?, ?)", p))
+      // This assertion FAILS with the current (buggy) implementation
+      _      <- IO(assertEquals(result, " (100, 'John')"))
+    } yield ()
+  }
+
   test("buildBatchQuery should handle UPDATE statements correctly") {
     for {
       _      <- resetParams

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
@@ -252,7 +252,7 @@ class SharedPreparedStatementTest extends SharedPreparedStatement[IO], FTestPlat
       result <- params.get.map(p => buildBatchQuery("INSERT INTO users (id, name) values (?, ?)", p))
       // split("VALUES") does not match lowercase "values", so .last returns the entire query string
       // This assertion FAILS with the current (buggy) implementation
-      _      <- IO(assertEquals(result, " (100, 'John')"))
+      _ <- IO(assertEquals(result, " (100, 'John')"))
     } yield ()
   }
 
@@ -263,7 +263,7 @@ class SharedPreparedStatementTest extends SharedPreparedStatement[IO], FTestPlat
       _      <- setString(2, "John")
       result <- params.get.map(p => buildBatchQuery("INSERT INTO users (id, name) Values (?, ?)", p))
       // This assertion FAILS with the current (buggy) implementation
-      _      <- IO(assertEquals(result, " (100, 'John')"))
+      _ <- IO(assertEquals(result, " (100, 'John')"))
     } yield ()
   }
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

`SharedPreparedStatement.buildBatchQuery` had inconsistent case handling for the `VALUES` keyword:

```scala
// Before (buggy) — case-insensitive INSERT detection, case-sensitive VALUES split
original.trim.toLowerCase match
  case q if q.startsWith("insert") =>      // toLowerCase → case-insensitive
    val bindQuery = buildQuery(original, params)
    bindQuery.split("VALUES").last          // literal "VALUES" → case-sensitive
```

When a query used lowercase `values` or mixed-case `Values`, `split("VALUES")` found no match and returned the entire query string, producing malformed batch queries.

### Fix

Applied the `(?i)` regex flag to make the split case-insensitive:

```scala
bindQuery.split("(?i)VALUES").last
```

### Test

Added two tests to `SharedPreparedStatementTest` that verify `buildBatchQuery` correctly extracts the values clause regardless of keyword casing:

- `INSERT INTO users (id, name) values (?, ?)` — lowercase
- `INSERT INTO users (id, name) Values (?, ?)` — mixed-case

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/711

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
