### PR TITLE
Bugfix/2026 05 issues 712

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
@@ -190,7 +190,18 @@ case class ClientPreparedStatement[F[_]: Exchange: Tracer: Sync](
     }
 
   override def execute(): F[Boolean] =
-    if sql.toUpperCase.startsWith("SELECT") then
+    val trimmedUpper = sql.trim.toUpperCase
+    if trimmedUpper.startsWith("SELECT") ||
+       trimmedUpper.startsWith("SHOW") ||
+       trimmedUpper.startsWith("DESC") ||
+       trimmedUpper.startsWith("EXPLAIN") ||
+       trimmedUpper.startsWith("WITH") ||
+       trimmedUpper.startsWith("TABLE") ||
+       trimmedUpper.startsWith("OPTIMIZE") ||
+       trimmedUpper.startsWith("CHECK") ||
+       trimmedUpper.startsWith("REPAIR") ||
+       trimmedUpper.startsWith("ANALYZE") ||
+       trimmedUpper.startsWith("(") then
       executeQuery().flatMap {
         case resultSet: ResultSetImpl[F] => resultSet.hasRows()
         case _                           => F.pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ClientPreparedStatement.scala
@@ -192,16 +192,17 @@ case class ClientPreparedStatement[F[_]: Exchange: Tracer: Sync](
   override def execute(): F[Boolean] =
     val trimmedUpper = sql.trim.toUpperCase
     if trimmedUpper.startsWith("SELECT") ||
-       trimmedUpper.startsWith("SHOW") ||
-       trimmedUpper.startsWith("DESC") ||
-       trimmedUpper.startsWith("EXPLAIN") ||
-       trimmedUpper.startsWith("WITH") ||
-       trimmedUpper.startsWith("TABLE") ||
-       trimmedUpper.startsWith("OPTIMIZE") ||
-       trimmedUpper.startsWith("CHECK") ||
-       trimmedUpper.startsWith("REPAIR") ||
-       trimmedUpper.startsWith("ANALYZE") ||
-       trimmedUpper.startsWith("(") then
+      trimmedUpper.startsWith("SHOW") ||
+      trimmedUpper.startsWith("DESC") ||
+      trimmedUpper.startsWith("EXPLAIN") ||
+      trimmedUpper.startsWith("WITH") ||
+      trimmedUpper.startsWith("TABLE") ||
+      trimmedUpper.startsWith("OPTIMIZE") ||
+      trimmedUpper.startsWith("CHECK") ||
+      trimmedUpper.startsWith("REPAIR") ||
+      trimmedUpper.startsWith("ANALYZE") ||
+      trimmedUpper.startsWith("(")
+    then
       executeQuery().flatMap {
         case resultSet: ResultSetImpl[F] => resultSet.hasRows()
         case _                           => F.pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
@@ -205,16 +205,17 @@ case class ServerPreparedStatement[F[_]: Exchange: Tracer: Sync](
   override def execute(): F[Boolean] =
     val trimmedUpper = sql.trim.toUpperCase
     if trimmedUpper.startsWith("SELECT") ||
-       trimmedUpper.startsWith("SHOW") ||
-       trimmedUpper.startsWith("DESC") ||
-       trimmedUpper.startsWith("EXPLAIN") ||
-       trimmedUpper.startsWith("WITH") ||
-       trimmedUpper.startsWith("TABLE") ||
-       trimmedUpper.startsWith("OPTIMIZE") ||
-       trimmedUpper.startsWith("CHECK") ||
-       trimmedUpper.startsWith("REPAIR") ||
-       trimmedUpper.startsWith("ANALYZE") ||
-       trimmedUpper.startsWith("(") then
+      trimmedUpper.startsWith("SHOW") ||
+      trimmedUpper.startsWith("DESC") ||
+      trimmedUpper.startsWith("EXPLAIN") ||
+      trimmedUpper.startsWith("WITH") ||
+      trimmedUpper.startsWith("TABLE") ||
+      trimmedUpper.startsWith("OPTIMIZE") ||
+      trimmedUpper.startsWith("CHECK") ||
+      trimmedUpper.startsWith("REPAIR") ||
+      trimmedUpper.startsWith("ANALYZE") ||
+      trimmedUpper.startsWith("(")
+    then
       executeQuery().flatMap {
         case resultSet: ResultSetImpl[F] => resultSet.hasRows()
         case _                           => F.pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/ServerPreparedStatement.scala
@@ -203,7 +203,18 @@ case class ServerPreparedStatement[F[_]: Exchange: Tracer: Sync](
     }
 
   override def execute(): F[Boolean] =
-    if sql.toUpperCase.startsWith("SELECT") then
+    val trimmedUpper = sql.trim.toUpperCase
+    if trimmedUpper.startsWith("SELECT") ||
+       trimmedUpper.startsWith("SHOW") ||
+       trimmedUpper.startsWith("DESC") ||
+       trimmedUpper.startsWith("EXPLAIN") ||
+       trimmedUpper.startsWith("WITH") ||
+       trimmedUpper.startsWith("TABLE") ||
+       trimmedUpper.startsWith("OPTIMIZE") ||
+       trimmedUpper.startsWith("CHECK") ||
+       trimmedUpper.startsWith("REPAIR") ||
+       trimmedUpper.startsWith("ANALYZE") ||
+       trimmedUpper.startsWith("(") then
       executeQuery().flatMap {
         case resultSet: ResultSetImpl[F] => resultSet.hasRows()
         case _                           => F.pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/SharedPreparedStatement.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/SharedPreparedStatement.scala
@@ -116,6 +116,6 @@ private[ldbc] trait SharedPreparedStatement[F[_]: Sync] extends PreparedStatemen
     original.trim.toLowerCase match
       case q if q.startsWith("insert") =>
         val bindQuery = buildQuery(original, params)
-        bindQuery.split("VALUES").last
+        bindQuery.split("(?i)VALUES").last
       case q if q.startsWith("update") || q.startsWith("delete") => buildQuery(original, params)
       case _ => throw new IllegalArgumentException("The batch query must be an INSERT, UPDATE, or DELETE statement.")

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -278,16 +278,17 @@ private[ldbc] case class StatementImpl[F[_]: Exchange: Tracer: Sync](
     checkClosed() *> checkNullOrEmptyQuery(sql) *> {
       val trimmedUpper = sql.trim.toUpperCase
       if trimmedUpper.startsWith("SELECT") ||
-         trimmedUpper.startsWith("SHOW") ||
-         trimmedUpper.startsWith("DESC") ||
-         trimmedUpper.startsWith("EXPLAIN") ||
-         trimmedUpper.startsWith("WITH") ||
-         trimmedUpper.startsWith("TABLE") ||
-         trimmedUpper.startsWith("OPTIMIZE") ||
-         trimmedUpper.startsWith("CHECK") ||
-         trimmedUpper.startsWith("REPAIR") ||
-         trimmedUpper.startsWith("ANALYZE") ||
-         trimmedUpper.startsWith("(") then
+        trimmedUpper.startsWith("SHOW") ||
+        trimmedUpper.startsWith("DESC") ||
+        trimmedUpper.startsWith("EXPLAIN") ||
+        trimmedUpper.startsWith("WITH") ||
+        trimmedUpper.startsWith("TABLE") ||
+        trimmedUpper.startsWith("OPTIMIZE") ||
+        trimmedUpper.startsWith("CHECK") ||
+        trimmedUpper.startsWith("REPAIR") ||
+        trimmedUpper.startsWith("ANALYZE") ||
+        trimmedUpper.startsWith("(")
+      then
         executeQuery(sql).flatMap {
           case resultSet: ResultSetImpl[F] => resultSet.hasRows()
           case _                           => F.pure(false)

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/protocol/StatementImpl.scala
@@ -275,14 +275,25 @@ private[ldbc] case class StatementImpl[F[_]: Exchange: Tracer: Sync](
   override def close(): F[Unit] = statementClosed.set(true) *> resultSetClosed.set(true)
 
   override def execute(sql: String): F[Boolean] =
-    checkClosed() *> checkNullOrEmptyQuery(sql) *> (
-      if sql.toUpperCase.startsWith("SELECT") then
+    checkClosed() *> checkNullOrEmptyQuery(sql) *> {
+      val trimmedUpper = sql.trim.toUpperCase
+      if trimmedUpper.startsWith("SELECT") ||
+         trimmedUpper.startsWith("SHOW") ||
+         trimmedUpper.startsWith("DESC") ||
+         trimmedUpper.startsWith("EXPLAIN") ||
+         trimmedUpper.startsWith("WITH") ||
+         trimmedUpper.startsWith("TABLE") ||
+         trimmedUpper.startsWith("OPTIMIZE") ||
+         trimmedUpper.startsWith("CHECK") ||
+         trimmedUpper.startsWith("REPAIR") ||
+         trimmedUpper.startsWith("ANALYZE") ||
+         trimmedUpper.startsWith("(") then
         executeQuery(sql).flatMap {
           case resultSet: ResultSetImpl[F] => resultSet.hasRows()
           case _                           => F.pure(false)
         }
       else executeUpdate(sql).map(_ => false)
-    )
+    }
 
   override def addBatch(sql: String): F[Unit] = batchedArgs.update(_ :+ sql)
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/StatementQueryTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/StatementQueryTest.scala
@@ -688,3 +688,173 @@ class StatementQueryTest extends FTestPlatform:
       0
     )
   }
+
+  // ---------------------------------------------------------------------------
+  // Bug #712: execute() throws MatchError for result-set-returning statements
+  // that do not begin with "SELECT"
+  // ---------------------------------------------------------------------------
+
+  test("Bug #712: Statement.execute should return true for SHOW DATABASES") {
+    // execute() checks sql.toUpperCase.startsWith("SELECT") only.
+    // "SHOW DATABASES" does not start with SELECT, so it is routed to executeUpdate(),
+    // which cannot handle a result-set response → MatchError.
+    // This test FAILS with the current (buggy) implementation.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("SHOW DATABASES")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Bug #712: Statement.execute should return true for DESCRIBE") {
+    // Same root cause: "DESCRIBE" does not start with "SELECT".
+    // This test FAILS with the current (buggy) implementation.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("DESCRIBE `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Bug #712: Statement.execute should return true for EXPLAIN") {
+    // Same root cause: "EXPLAIN" does not start with "SELECT".
+    // This test FAILS with the current (buggy) implementation.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("EXPLAIN SELECT 1")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Bug #712: Statement.execute should return true for SELECT with leading whitespace") {
+    // "  SELECT 1".toUpperCase.startsWith("SELECT") is false because of the leading spaces,
+    // so it is incorrectly routed to executeUpdate() → MatchError.
+    // This test FAILS with the current (buggy) implementation.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("  SELECT 1")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Bug #712: Statement.execute should return true for parenthesized SELECT") {
+    // "( SELECT 1 )".toUpperCase.startsWith("SELECT") is false,
+    // so it is incorrectly routed to executeUpdate() → MatchError.
+    // This test FAILS with the current (buggy) implementation.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("( SELECT 1 )")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for CTE (WITH ... SELECT)") {
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("WITH cte AS (SELECT 1 AS n) SELECT n FROM cte")
+        yield hasResult
+      }
+    )
+  }
+
+  // ---------------------------------------------------------------------------
+  // Result-set-returning statements: missing keyword coverage investigation
+  // Each test would throw MatchError (or return wrong result) if the keyword
+  // is not routed to executeQuery() in execute().
+  // ---------------------------------------------------------------------------
+
+  test("Statement.execute should return true for DESC (abbreviation of DESCRIBE)") {
+    // DESC is the short form of DESCRIBE. startsWith("DESCRIBE") does NOT catch
+    // "DESC tablename", so without "DESC" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("DESC `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for TABLE statement (MySQL 8.0.19+)") {
+    // TABLE tbl is equivalent to SELECT * FROM tbl ORDER BY primary key.
+    // Without "TABLE" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          _         <- statement.executeUpdate("USE `connector_test`")
+          hasResult <- statement.execute("TABLE `all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for OPTIMIZE TABLE") {
+    // OPTIMIZE TABLE returns a result set (Table/Op/Msg_type/Msg_text rows).
+    // Without "OPTIMIZE" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("OPTIMIZE TABLE `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for CHECK TABLE") {
+    // CHECK TABLE returns a result set (Table/Op/Msg_type/Msg_text rows).
+    // Without "CHECK" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("CHECK TABLE `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for REPAIR TABLE") {
+    // REPAIR TABLE returns a result set (Table/Op/Msg_type/Msg_text rows).
+    // Without "REPAIR" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("REPAIR TABLE `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }
+
+  test("Statement.execute should return true for ANALYZE TABLE") {
+    // ANALYZE TABLE returns a result set (Table/Op/Msg_type/Msg_text rows).
+    // Without "ANALYZE" in the routing it hits executeUpdate() → MatchError.
+    assertIOBoolean(
+      connection.use { conn =>
+        for
+          statement <- conn.createStatement()
+          hasResult <- statement.execute("ANALYZE TABLE `connector_test`.`all_types`")
+        yield hasResult
+      }
+    )
+  }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

`StatementImpl`, `ClientPreparedStatement`, and `ServerPreparedStatement` all routed only `SELECT` to `executeQuery()`. Statements such as `SHOW`, `DESCRIBE`/`DESC`, `EXPLAIN`, `WITH` (CTE), `TABLE`, `OPTIMIZE TABLE`, `CHECK TABLE`, `REPAIR TABLE`, `ANALYZE TABLE`, and parenthesized `(SELECT ...)` were incorrectly routed to `executeUpdate()`, causing a `MatchError` in `GenericResponsePackets.decoder` when the server returned a result-set response.

**Fix:** Extend the routing condition in `execute()` across all three statement classes.

```scala
val trimmedUpper = sql.trim.toUpperCase
if trimmedUpper.startsWith("SELECT") ||
   trimmedUpper.startsWith("SHOW") ||
   trimmedUpper.startsWith("DESC") ||      // covers DESC and DESCRIBE
   trimmedUpper.startsWith("EXPLAIN") ||
   trimmedUpper.startsWith("WITH") ||      // CTE
   trimmedUpper.startsWith("TABLE") ||     // MySQL 8.0.19+ TABLE statement
   trimmedUpper.startsWith("OPTIMIZE") ||
   trimmedUpper.startsWith("CHECK") ||
   trimmedUpper.startsWith("REPAIR") ||
   trimmedUpper.startsWith("ANALYZE") ||
   trimmedUpper.startsWith("(") then       // UNION / parenthesized SELECT
  executeQuery(sql)...
else
  executeUpdate(sql)...
```

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/712

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
