### PR TITLE
Bugfix/2026 05 issues 716

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/Parameter.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/Parameter.scala
@@ -97,7 +97,7 @@ object Parameter:
 
   def string(value: String): Parameter = new Parameter:
     override def columnDataType: ColumnDataType = ColumnDataType.MYSQL_TYPE_STRING
-    override def sql: String =
+    override def sql:            String         =
       val sb = new StringBuilder("'")
       value.foreach {
         case '\u0000' => sb.append("\\0")

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/Parameter.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/Parameter.scala
@@ -97,8 +97,21 @@ object Parameter:
 
   def string(value: String): Parameter = new Parameter:
     override def columnDataType: ColumnDataType = ColumnDataType.MYSQL_TYPE_STRING
-    override def sql:            String         = "'" + value.replaceAll("'", "''").replaceAll("\\\\", "\\\\\\\\") + "'"
-    override def encode:         BitVector      =
+    override def sql: String =
+      val sb = new StringBuilder("'")
+      value.foreach {
+        case '\u0000' => sb.append("\\0")
+        case '\n'     => sb.append("\\n")
+        case '\r'     => sb.append("\\r")
+        case '\\'     => sb.append("\\\\")
+        case '\''     => sb.append("\\'")
+        case '"'      => sb.append("\\\"")
+        case '\u001a' => sb.append("\\Z")
+        case '\b'     => sb.append("\\b")
+        case c        => sb.append(c)
+      }
+      sb.append("'").toString
+    override def encode: BitVector =
       val bytes = value.getBytes
       BitVector(bytes.length) |+| BitVector(copyOf(bytes, bytes.length))
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/data/ParameterTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/data/ParameterTest.scala
@@ -162,9 +162,9 @@ class ParameterTest extends FTestPlatform:
     val emptyStringParam = Parameter.string("")
     assertEquals(emptyStringParam.toString, "''")
 
-    // Test string with quotes
+    // Test string with quotes (single quote is escaped as \' per MySQL text protocol)
     val quotedStringParam = Parameter.string("test'quotes")
-    assertEquals(quotedStringParam.toString, "'test''quotes'")
+    assertEquals(quotedStringParam.toString, "'test\\'quotes'")
 
     // Test zero values
     assertEquals(Parameter.byte(0).toString, "0")
@@ -246,13 +246,13 @@ class ParameterTest extends FTestPlatform:
   }
 
   test("String parameter special cases") {
-    // Multiline string
+    // Multiline string: newlines are escaped as \n per MySQL text protocol
     val multilineString = "line1\nline2\nline3"
-    assertEquals(Parameter.string(multilineString).toString, s"'$multilineString'")
+    assertEquals(Parameter.string(multilineString).toString, "'line1\\nline2\\nline3'")
 
-    // String with special characters
+    // String with special characters: \r, \n, \b are escaped; \t is not in MySQL's escape list
     val specialChars = "\t\r\n\b"
-    assertEquals(Parameter.string(specialChars).toString, s"'$specialChars'")
+    assertEquals(Parameter.string(specialChars).toString, "'\t\\r\\n\\b'")
 
     // Unicode string
     val unicodeString = "Hello 世界 🌍"

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
@@ -281,7 +281,7 @@ class SharedPreparedStatementTest extends SharedPreparedStatement[IO], FTestPlat
     // Correct: escapes \ first → \\ then escapes ' → \\\'
     //   Result: '\\\''
     val input    = "\\'"
-    val expected = "'\\\\\\''"  // '\\\''  in the actual string
+    val expected = "'\\\\\\''" // '\\\''  in the actual string
     IO(assertEquals(Parameter.string(input).sql, expected))
   }
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/protocol/SharedPreparedStatementTest.scala
@@ -270,6 +270,57 @@ class SharedPreparedStatementTest extends SharedPreparedStatement[IO], FTestPlat
     } yield ()
   }
 
+  // ---------------------------------------------------------------------------
+  // Bug #716: Parameter.string SQL escaping is incomplete and misordered
+  // ---------------------------------------------------------------------------
+
+  test("Bug #716: Parameter.string should escape backslash before single quote") {
+    // Input: \'  (backslash followed by single quote)
+    // Current (buggy): escapes ' first → \'' then escapes \ → \\''
+    //   Result: '\\'''  — leaves an unescaped quote, enabling injection
+    // Correct: escapes \ first → \\ then escapes ' → \\\'
+    //   Result: '\\\''
+    val input    = "\\'"
+    val expected = "'\\\\\\''"  // '\\\''  in the actual string
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape NUL character") {
+    val input    = "a\u0000b"
+    val expected = "'a\\0b'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape newline") {
+    val input    = "a\nb"
+    val expected = "'a\\nb'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape carriage return") {
+    val input    = "a\rb"
+    val expected = "'a\\rb'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape double quote") {
+    val input    = "a\"b"
+    val expected = "'a\\\"b'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape Ctrl-Z") {
+    val input    = "a\u001ab"
+    val expected = "'a\\Zb'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
+  test("Bug #716: Parameter.string should escape backspace") {
+    val input    = "a\bb"
+    val expected = "'a\\bb'"
+    IO(assertEquals(Parameter.string(input).sql, expected))
+  }
+
   override def executeQuery(): IO[ResultSet[IO]] =
     IO.raiseError(new UnsupportedOperationException("Not implemented for test"))
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

The text-protocol escaping in `Parameter.string` had two issues:

**1. Wrong order of operations**

Single quotes were escaped before backslashes. An input like `\'` became `\''` after quote-escaping, then `\\''` after backslash-escaping — leaving an unescaped quote that enables injection. Backslashes must be escaped first.

**2. Incomplete character coverage**

Only `'` and `\` were escaped. MySQL's text protocol requires the following characters to be escaped:

| Character | Escape |
|---|---|
| NUL (`\0`) | `\0` |
| Newline | `\n` |
| Carriage return | `\r` |
| Backslash | `\\` |
| Single quote | `\'` |
| Double quote | `\"` |
| Ctrl-Z (`\u001a`) | `\Z` |
| Backspace | `\b` |

**Fix:** Replace the chained `replaceAll` calls with a single character-by-character pass that handles all required characters in the correct order.

```scala
// Before
"'" + value.replaceAll("'", "''").replaceAll("\\\\", "\\\\\\\\") + "'"

// After
val sb = new StringBuilder("'")
value.foreach {
  case '\u0000' => sb.append("\\0")
  case '\n'     => sb.append("\\n")
  case '\r'     => sb.append("\\r")
  case '\\'     => sb.append("\\\\")
  case '\''     => sb.append("\\'")
  case '"'      => sb.append("\\\"")
  case '\u001a' => sb.append("\\Z")
  case '\b'     => sb.append("\\b")
  case c        => sb.append(c)
}
sb.append("'").toString
```

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/716

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
