### PR TITLE
Bugfix/2026 05 issues 718

### DIFF
--- a/module/ldbc-connector/jvm/src/test/scala/ldbc/connector/SSLTest.scala
+++ b/module/ldbc-connector/jvm/src/test/scala/ldbc/connector/SSLTest.scala
@@ -61,6 +61,26 @@ class SSLTest extends FTestPlatform:
     assertEquals(ssl.fallbackOk, true)
   }
 
+  test("Bug #718: withTLSParameters should preserve fallbackOk when chained after withFallback") {
+    // withFallback(true).withTLSParameters(customParams) silently resets fallbackOk to false
+    // because withTLSParameters creates a new anonymous SSL that only overrides tlsParameters
+    // and falls through to the trait default (false) for fallbackOk instead of outer.fallbackOk.
+    val customParams = TLSParameters(serverNames = Some(List(new SNIHostName("test-server"))))
+    val ssl = SSL.Trusted.withFallback(true).withTLSParameters(customParams)
+    assertEquals(ssl.tlsParameters, customParams)
+    assertEquals(ssl.fallbackOk, true, "fallbackOk should be preserved after chaining withTLSParameters")
+  }
+
+  test("Bug #718: withFallback should preserve tlsParameters when chained after withTLSParameters") {
+    // withTLSParameters(customParams).withFallback(true) silently resets tlsParameters to Default
+    // because withFallback creates a new anonymous SSL that only overrides fallbackOk
+    // and falls through to the trait default (TLSParameters.Default) for tlsParameters.
+    val customParams = TLSParameters(serverNames = Some(List(new SNIHostName("test-server"))))
+    val ssl = SSL.Trusted.withTLSParameters(customParams).withFallback(true)
+    assertEquals(ssl.fallbackOk, true)
+    assertEquals(ssl.tlsParameters, customParams, "tlsParameters should be preserved after chaining withFallback")
+  }
+
   test("toSSLNegotiationOptions should return None for SSL.None") {
     assertIO(
       SSL.None.toSSLNegotiationOptions[IO](None).use(IO.pure),

--- a/module/ldbc-connector/jvm/src/test/scala/ldbc/connector/SSLTest.scala
+++ b/module/ldbc-connector/jvm/src/test/scala/ldbc/connector/SSLTest.scala
@@ -66,7 +66,7 @@ class SSLTest extends FTestPlatform:
     // because withTLSParameters creates a new anonymous SSL that only overrides tlsParameters
     // and falls through to the trait default (false) for fallbackOk instead of outer.fallbackOk.
     val customParams = TLSParameters(serverNames = Some(List(new SNIHostName("test-server"))))
-    val ssl = SSL.Trusted.withFallback(true).withTLSParameters(customParams)
+    val ssl          = SSL.Trusted.withFallback(true).withTLSParameters(customParams)
     assertEquals(ssl.tlsParameters, customParams)
     assertEquals(ssl.fallbackOk, true, "fallbackOk should be preserved after chaining withTLSParameters")
   }
@@ -76,7 +76,7 @@ class SSLTest extends FTestPlatform:
     // because withFallback creates a new anonymous SSL that only overrides fallbackOk
     // and falls through to the trait default (TLSParameters.Default) for tlsParameters.
     val customParams = TLSParameters(serverNames = Some(List(new SNIHostName("test-server"))))
-    val ssl = SSL.Trusted.withTLSParameters(customParams).withFallback(true)
+    val ssl          = SSL.Trusted.withTLSParameters(customParams).withFallback(true)
     assertEquals(ssl.fallbackOk, true)
     assertEquals(ssl.tlsParameters, customParams, "tlsParameters should be preserved after chaining withFallback")
   }

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/SSL.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/SSL.scala
@@ -29,13 +29,13 @@ trait SSL:
   def withTLSParameters(_tlsParameters: TLSParameters): SSL =
     new SSL:
       override def tlsParameters: TLSParameters = _tlsParameters
-      override def fallbackOk:    Boolean        = outer.fallbackOk
+      override def fallbackOk:    Boolean       = outer.fallbackOk
       override def tlsContext[F[_]: Network](using ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext
 
   def withFallback(_fallbackOk: Boolean): SSL =
     new SSL:
-      override def fallbackOk:    Boolean        = _fallbackOk
+      override def fallbackOk:    Boolean       = _fallbackOk
       override def tlsParameters: TLSParameters = outer.tlsParameters
       override def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/SSL.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/SSL.scala
@@ -29,12 +29,14 @@ trait SSL:
   def withTLSParameters(_tlsParameters: TLSParameters): SSL =
     new SSL:
       override def tlsParameters: TLSParameters = _tlsParameters
+      override def fallbackOk:    Boolean        = outer.fallbackOk
       override def tlsContext[F[_]: Network](using ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext
 
   def withFallback(_fallbackOk: Boolean): SSL =
     new SSL:
-      override def fallbackOk: Boolean = _fallbackOk
+      override def fallbackOk:    Boolean        = _fallbackOk
+      override def tlsParameters: TLSParameters = outer.tlsParameters
       override def tlsContext[F[_]: Network](implicit ev: ApplicativeError[F, Throwable]): Resource[F, TLSContext[F]] =
         outer.tlsContext
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

Each builder method created an anonymous `SSL` that overrode only its own property, while the other property fell through to the **trait default** instead of `outer`'s value. This caused silent data loss when the two methods were chained in either order.

```scala
// Before: chaining drops the first property
SSL.Trusted.withFallback(true).withTLSParameters(customParams)
// → tlsParameters = customParams  ✓
// → fallbackOk    = false         ✗ (reset to trait default)

SSL.Trusted.withTLSParameters(customParams).withFallback(true)
// → tlsParameters = TLSParameters.Default  ✗ (reset to trait default)
// → fallbackOk    = true                   ✓
```

**Fix:** Forward the unchanged property from `outer` in each builder.

```scala
// withTLSParameters: propagate fallbackOk from outer
def withTLSParameters(_tlsParameters: TLSParameters): SSL =
  new SSL:
    override def tlsParameters: TLSParameters = _tlsParameters
    override def fallbackOk:    Boolean        = outer.fallbackOk  // added
    override def tlsContext[F[_]: Network](...) = outer.tlsContext

// withFallback: propagate tlsParameters from outer
def withFallback(_fallbackOk: Boolean): SSL =
  new SSL:
    override def fallbackOk:    Boolean        = _fallbackOk
    override def tlsParameters: TLSParameters = outer.tlsParameters  // added
    override def tlsContext[F[_]: Network](...) = outer.tlsContext
```

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/718

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
