### PR TITLE
Bugfix/2026 05 issues 713

### DIFF
--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
@@ -452,7 +452,7 @@ trait DataTypeParser extends SqlParser:
 
   private[ldbc] def mediumblobType: Parser[DataType] =
     customError(
-      caseSensitivity("mediumblob") ^^ (_ => DataType.TINYBLOB()),
+      caseSensitivity("mediumblob") ^^ (_ => DataType.MEDIUMBLOB()),
       input => s"""
         |===============================================================================
         |Failed to parse mediumblob data type.

--- a/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
+++ b/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
@@ -8,6 +8,8 @@ package ldbc.codegen.parser
 
 import munit.CatsEffectSuite
 
+import ldbc.codegen.model.DataType
+
 class DataTypeParserTest extends CatsEffectSuite, DataTypeParser:
 
   override def fileName: String = "test.sql"
@@ -350,6 +352,12 @@ class DataTypeParserTest extends CatsEffectSuite, DataTypeParser:
     assert(parseAll(mediumblobType, "mediumblob").successful)
     assert(parseAll(mediumblobType, "Mediumblob").successful)
     assert(parseAll(mediumblobType, "MEDIUMBLOB").successful)
+  }
+
+  test("MEDIUMBLOB data type parsing should produce DataType.MEDIUMBLOB not DataType.TINYBLOB") {
+    val result = parseAll(mediumblobType, "MEDIUMBLOB")
+    assert(result.successful)
+    assertEquals(result.get, DataType.MEDIUMBLOB())
   }
 
   test("MEDIUMBLOB data type parsing test fails.") {


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

**Root Cause**

Copy-paste error in `DataTypeParser.scala` — `mediumblobType` parser correctly matched the `MEDIUMBLOB` keyword but returned `DataType.TINYBLOB()` instead of `DataType.MEDIUMBLOB()`.

```scala
// Before (buggy)
caseSensitivity("mediumblob") ^^ (_ => DataType.TINYBLOB())

// After
caseSensitivity("mediumblob") ^^ (_ => DataType.MEDIUMBLOB())
```

**Impact**

Code generation from DDL containing `MEDIUMBLOB` columns produced `TINYBLOB` type instead, causing a type mismatch between the schema definition and generated code.

**Changes**

- `DataTypeParser.scala`: Fixed return value in `mediumblobType` from `DataType.TINYBLOB()` to `DataType.MEDIUMBLOB()`
- `DataTypeParserTest.scala`: Added assertion to verify the produced `DataType` value is `DataType.MEDIUMBLOB()`, not just that parsing succeeds

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/713

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
