### PR TITLE
Bugfix/2026 05 issues 731

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
@@ -14,25 +14,27 @@ import cats.*
 import cats.syntax.all.*
 
 import cats.effect.*
+import cats.effect.syntax.all.*
 
 import ldbc.connector.exception.SQLException
 
 /**
  * Circuit breaker pattern implementation for connection creation.
- * 
+ *
  * Prevents thundering herd problem when database is down by failing fast
  * instead of attempting to create connections that will likely fail.
- * 
+ *
  * States:
  * - Closed: Normal operation, connections are created
  * - Open: Failures exceeded threshold, fail fast
- * - HalfOpen: Testing if service recovered
+ * - HalfOpen: Reset timeout elapsed, ready to accept one test request
+ * - Probing: HalfOpen and one fiber is actively verifying service recovery
  */
 trait CircuitBreaker[F[_]]:
 
   /**
    * Execute an action through the circuit breaker.
-   * 
+   *
    * @param action the action to protect
    * @return the result or failure if circuit is open
    */
@@ -54,6 +56,7 @@ object CircuitBreaker:
     case Closed
     case Open
     case HalfOpen
+    case Probing
 
   case class Config(
     maxFailures:              Int            = 5,
@@ -103,8 +106,14 @@ object CircuitBreaker:
         case State.Open =>
           checkIfShouldTransitionToHalfOpen.flatMap { shouldTransition =>
             if shouldTransition then
-              // Transition to half-open and try
-              stateRef.set(State.HalfOpen) >> protect(action)
+              // Atomically claim the HalfOpen transition: only the first fiber wins
+              stateRef.modify {
+                case State.Open => (State.HalfOpen, true)
+                case other      => (other, false)
+              }.flatMap {
+                case true  => protect(action)
+                case false => Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
+              }
             else
               // Still open, fail fast
               Temporal[F].raiseError(
@@ -112,28 +121,45 @@ object CircuitBreaker:
               )
           }
 
-        case State.HalfOpen =>
-          // Single test request
-          action
-            .handleErrorWith { error =>
-              // Failed again, back to open with increased timeout
-              stateRef.set(State.Open) *>
-                failuresRef.set(0) *>
-                currentResetTimeoutRef.get.flatMap { currentTimeout =>
-                  val newTimeout = FiniteDuration(
-                    (currentTimeout.toNanos * config.exponentialBackoffFactor).toLong
-                      .min(config.maxResetTimeout.toNanos),
-                    TimeUnit.NANOSECONDS
-                  )
-                  currentResetTimeoutRef.set(newTimeout)
-                } *>
-                Clock[F].realTime.flatMap(now => lastFailureTimeRef.set(now.toMillis)) *>
-                Temporal[F].raiseError[A](error)
-            }
-            .flatMap { result =>
-              // Success, close the circuit
-              reset.as(result)
-            }
+        case State.HalfOpen | State.Probing =>
+          // Atomically claim the single test slot: only one fiber transitions to Probing
+          stateRef.modify {
+            case State.HalfOpen => (State.Probing, true)
+            case other          => (other, false)
+          }.flatMap {
+            case false =>
+              // Another fiber is already probing, fail fast
+              Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
+            case true =>
+              action
+                .handleErrorWith { error =>
+                  // Failed again, back to open with increased timeout
+                  stateRef.set(State.Open) *>
+                    failuresRef.set(0) *>
+                    currentResetTimeoutRef.get.flatMap { currentTimeout =>
+                      val newTimeout = FiniteDuration(
+                        (currentTimeout.toNanos * config.exponentialBackoffFactor).toLong
+                          .min(config.maxResetTimeout.toNanos),
+                        TimeUnit.NANOSECONDS
+                      )
+                      currentResetTimeoutRef.set(newTimeout)
+                    } *>
+                    Clock[F].realTime.flatMap(now => lastFailureTimeRef.set(now.toMillis)) *>
+                    Temporal[F].raiseError[A](error)
+                }
+                .flatMap { result =>
+                  // Success, close the circuit
+                  reset.as(result)
+                }
+                .guarantee {
+                  // On cancellation, restore Probing -> HalfOpen so the next fiber can retry.
+                  // On success or failure, state is already Closed / Open, so this is a no-op.
+                  stateRef.modify {
+                    case State.Probing => (State.HalfOpen, ())
+                    case other         => (other, ())
+                  }.void
+                }
+          }
       }
 
     private def recordFailure: F[Unit] =

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/pool/CircuitBreaker.scala
@@ -107,13 +107,15 @@ object CircuitBreaker:
           checkIfShouldTransitionToHalfOpen.flatMap { shouldTransition =>
             if shouldTransition then
               // Atomically claim the HalfOpen transition: only the first fiber wins
-              stateRef.modify {
-                case State.Open => (State.HalfOpen, true)
-                case other      => (other, false)
-              }.flatMap {
-                case true  => protect(action)
-                case false => Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
-              }
+              stateRef
+                .modify {
+                  case State.Open => (State.HalfOpen, true)
+                  case other      => (other, false)
+                }
+                .flatMap {
+                  case true  => protect(action)
+                  case false => Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
+                }
             else
               // Still open, fail fast
               Temporal[F].raiseError(
@@ -123,43 +125,45 @@ object CircuitBreaker:
 
         case State.HalfOpen | State.Probing =>
           // Atomically claim the single test slot: only one fiber transitions to Probing
-          stateRef.modify {
-            case State.HalfOpen => (State.Probing, true)
-            case other          => (other, false)
-          }.flatMap {
-            case false =>
-              // Another fiber is already probing, fail fast
-              Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
-            case true =>
-              action
-                .handleErrorWith { error =>
-                  // Failed again, back to open with increased timeout
-                  stateRef.set(State.Open) *>
-                    failuresRef.set(0) *>
-                    currentResetTimeoutRef.get.flatMap { currentTimeout =>
-                      val newTimeout = FiniteDuration(
-                        (currentTimeout.toNanos * config.exponentialBackoffFactor).toLong
-                          .min(config.maxResetTimeout.toNanos),
-                        TimeUnit.NANOSECONDS
-                      )
-                      currentResetTimeoutRef.set(newTimeout)
-                    } *>
-                    Clock[F].realTime.flatMap(now => lastFailureTimeRef.set(now.toMillis)) *>
-                    Temporal[F].raiseError[A](error)
-                }
-                .flatMap { result =>
-                  // Success, close the circuit
-                  reset.as(result)
-                }
-                .guarantee {
-                  // On cancellation, restore Probing -> HalfOpen so the next fiber can retry.
-                  // On success or failure, state is already Closed / Open, so this is a no-op.
-                  stateRef.modify {
-                    case State.Probing => (State.HalfOpen, ())
-                    case other         => (other, ())
-                  }.void
-                }
-          }
+          stateRef
+            .modify {
+              case State.HalfOpen => (State.Probing, true)
+              case other          => (other, false)
+            }
+            .flatMap {
+              case false =>
+                // Another fiber is already probing, fail fast
+                Temporal[F].raiseError(new SQLException("Circuit breaker is open"))
+              case true =>
+                action
+                  .handleErrorWith { error =>
+                    // Failed again, back to open with increased timeout
+                    stateRef.set(State.Open) *>
+                      failuresRef.set(0) *>
+                      currentResetTimeoutRef.get.flatMap { currentTimeout =>
+                        val newTimeout = FiniteDuration(
+                          (currentTimeout.toNanos * config.exponentialBackoffFactor).toLong
+                            .min(config.maxResetTimeout.toNanos),
+                          TimeUnit.NANOSECONDS
+                        )
+                        currentResetTimeoutRef.set(newTimeout)
+                      } *>
+                      Clock[F].realTime.flatMap(now => lastFailureTimeRef.set(now.toMillis)) *>
+                      Temporal[F].raiseError[A](error)
+                  }
+                  .flatMap { result =>
+                    // Success, close the circuit
+                    reset.as(result)
+                  }
+                  .guarantee {
+                    // On cancellation, restore Probing -> HalfOpen so the next fiber can retry.
+                    // On success or failure, state is already Closed / Open, so this is a no-op.
+                    stateRef.modify {
+                      case State.Probing => (State.HalfOpen, ())
+                      case other         => (other, ())
+                    }.void
+                  }
+            }
       }
 
     private def recordFailure: F[Unit] =

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
@@ -270,3 +270,71 @@ class CircuitBreakerTest extends FTestPlatform:
       assertIO(cb.state, CircuitBreaker.State.Closed)
     }
   }
+
+  test("CircuitBreaker HalfOpen: only one concurrent fiber should be allowed as test request") {
+    val config = CircuitBreaker.Config(
+      maxFailures  = 1,
+      resetTimeout = 10.millis
+    )
+
+    CircuitBreaker[IO](config).flatMap { cb =>
+      for
+        counter <- Ref[IO].of(0)
+        gate    <- Deferred[IO, Unit]
+        // Open the circuit
+        _       <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
+        // Wait for reset timeout to expire
+        _       <- IO.sleep(20.millis)
+        // Fire 10 concurrent fibers.
+        // Each action increments counter before blocking at gate.
+        // This measures how many fibers actually entered the HalfOpen test action.
+        fibers  <- (1 to 10).toList.traverse { _ =>
+                     cb.protect(counter.update(_ + 1) >> gate.get).attempt.start
+                   }
+        // Give all fibers time to start and enter the action
+        _       <- IO.sleep(50.millis)
+        // Release all waiting fibers
+        _       <- gate.complete(())
+        _       <- fibers.traverse_(_.join)
+        count   <- counter.get
+      yield
+        // With the bug, multiple fibers enter HalfOpen simultaneously, so count > 1
+        assertEquals(count, 1, s"Only 1 fiber should enter HalfOpen as test request, but $count did")
+    }
+  }
+
+  test("CircuitBreaker HalfOpen: concurrent success should not reset failure's exponential backoff") {
+    val config = CircuitBreaker.Config(
+      maxFailures              = 1,
+      resetTimeout             = 10.millis,
+      exponentialBackoffFactor = 2.0
+    )
+
+    CircuitBreaker[IO](config).flatMap { cb =>
+      for
+        latch   <- Deferred[IO, Unit]
+        started <- Deferred[IO, Unit]
+        // Open the circuit
+        _       <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
+        // Wait for reset timeout to expire
+        _       <- IO.sleep(20.millis)
+        // Fiber 1: signals when it has entered the HalfOpen action, then waits for latch.
+        // Simulates a slow request that is still in-flight during HalfOpen.
+        f1      <- cb.protect(started.complete(()) >> latch.get >> IO.pure(())).start
+        // Wait until fiber 1 has started executing (past the Open -> HalfOpen state transition)
+        _       <- started.get
+        // Fiber 2: state is now HalfOpen, so it also enters and fails immediately.
+        // This should set state=Open with doubled backoff timeout (20ms).
+        _       <- cb.protect(IO.raiseError(new Exception("half-open fail"))).attempt
+        // Release fiber 1: it will succeed and call reset(), erasing fiber 2's backoff escalation.
+        _       <- latch.complete(())
+        _       <- f1.join
+        // State should remain Open (kept by fiber 2's failure) with doubled backoff.
+        finalState      <- cb.state
+        // Immediate retry should be blocked because the doubled backoff has not elapsed yet.
+        immediateResult <- cb.protect(IO.pure("test")).attempt
+      yield
+        assertEquals(finalState, CircuitBreaker.State.Open)
+        assert(immediateResult.isLeft, "Circuit breaker should remain open due to exponential backoff")
+    }
+  }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
@@ -282,21 +282,21 @@ class CircuitBreakerTest extends FTestPlatform:
         counter <- Ref[IO].of(0)
         gate    <- Deferred[IO, Unit]
         // Open the circuit
-        _       <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
+        _ <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
         // Wait for reset timeout to expire
-        _       <- IO.sleep(20.millis)
+        _ <- IO.sleep(20.millis)
         // Fire 10 concurrent fibers.
         // Each action increments counter before blocking at gate.
         // This measures how many fibers actually entered the HalfOpen test action.
-        fibers  <- (1 to 10).toList.traverse { _ =>
-                     cb.protect(counter.update(_ + 1) >> gate.get).attempt.start
-                   }
+        fibers <- (1 to 10).toList.traverse { _ =>
+                    cb.protect(counter.update(_ + 1) >> gate.get).attempt.start
+                  }
         // Give all fibers time to start and enter the action
-        _       <- IO.sleep(50.millis)
+        _ <- IO.sleep(50.millis)
         // Release all waiting fibers
-        _       <- gate.complete(())
-        _       <- fibers.traverse_(_.join)
-        count   <- counter.get
+        _     <- gate.complete(())
+        _     <- fibers.traverse_(_.join)
+        count <- counter.get
       yield
         // With the bug, multiple fibers enter HalfOpen simultaneously, so count > 1
         assertEquals(count, 1, s"Only 1 fiber should enter HalfOpen as test request, but $count did")
@@ -311,30 +311,30 @@ class CircuitBreakerTest extends FTestPlatform:
 
     CircuitBreaker[IO](config).flatMap { cb =>
       for
-        latch        <- Deferred[IO, Unit]
-        started      <- Deferred[IO, Unit]
+        latch   <- Deferred[IO, Unit]
+        started <- Deferred[IO, Unit]
         // Open the circuit
-        _            <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
+        _ <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
         // Wait for reset timeout to expire
-        _            <- IO.sleep(20.millis)
+        _ <- IO.sleep(20.millis)
         // Fiber 1: signals when it has entered the Probing action, then waits for latch.
         // This holds the Probing slot and keeps state=Probing while waiting.
-        f1           <- cb.protect(started.complete(()) >> latch.get >> IO.pure(())).start
+        f1 <- cb.protect(started.complete(()) >> latch.get >> IO.pure(())).start
         // Wait until fiber 1 has claimed the Probing slot (state=Probing)
-        _            <- started.get
+        _ <- started.get
         // Fiber 2: state is now Probing, so it should be rejected immediately (fail fast).
         fiber2Result <- cb.protect(IO.raiseError(new Exception("concurrent attempt"))).attempt
         // Release fiber 1 to succeed and close the circuit
-        _            <- latch.complete(())
-        _            <- f1.join
-        finalState   <- cb.state
+        _          <- latch.complete(())
+        _          <- f1.join
+        finalState <- cb.state
         // After the successful probe, normal requests should pass through
-        afterResult  <- cb.protect(IO.pure("recovered")).attempt
+        afterResult <- cb.protect(IO.pure("recovered")).attempt
       yield
         // Fiber 2 must be rejected with "circuit breaker is open" while probing is in progress
         assert(fiber2Result.isLeft, "Concurrent request should be rejected while probing")
         fiber2Result.left.foreach { err =>
-          assert(err.getMessage.contains("Circuit breaker is open"), s"Unexpected error: ${err.getMessage}")
+          assert(err.getMessage.contains("Circuit breaker is open"), s"Unexpected error: ${ err.getMessage }")
         }
         // After fiber 1's successful probe the circuit should be closed
         assertEquals(finalState, CircuitBreaker.State.Closed)

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/pool/CircuitBreakerTest.scala
@@ -303,38 +303,41 @@ class CircuitBreakerTest extends FTestPlatform:
     }
   }
 
-  test("CircuitBreaker HalfOpen: concurrent success should not reset failure's exponential backoff") {
+  test("CircuitBreaker Probing: concurrent requests should be rejected while one fiber is probing") {
     val config = CircuitBreaker.Config(
-      maxFailures              = 1,
-      resetTimeout             = 10.millis,
-      exponentialBackoffFactor = 2.0
+      maxFailures  = 1,
+      resetTimeout = 10.millis
     )
 
     CircuitBreaker[IO](config).flatMap { cb =>
       for
-        latch   <- Deferred[IO, Unit]
-        started <- Deferred[IO, Unit]
+        latch        <- Deferred[IO, Unit]
+        started      <- Deferred[IO, Unit]
         // Open the circuit
-        _       <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
+        _            <- cb.protect(IO.raiseError(new Exception("fail"))).attempt
         // Wait for reset timeout to expire
-        _       <- IO.sleep(20.millis)
-        // Fiber 1: signals when it has entered the HalfOpen action, then waits for latch.
-        // Simulates a slow request that is still in-flight during HalfOpen.
-        f1      <- cb.protect(started.complete(()) >> latch.get >> IO.pure(())).start
-        // Wait until fiber 1 has started executing (past the Open -> HalfOpen state transition)
-        _       <- started.get
-        // Fiber 2: state is now HalfOpen, so it also enters and fails immediately.
-        // This should set state=Open with doubled backoff timeout (20ms).
-        _       <- cb.protect(IO.raiseError(new Exception("half-open fail"))).attempt
-        // Release fiber 1: it will succeed and call reset(), erasing fiber 2's backoff escalation.
-        _       <- latch.complete(())
-        _       <- f1.join
-        // State should remain Open (kept by fiber 2's failure) with doubled backoff.
-        finalState      <- cb.state
-        // Immediate retry should be blocked because the doubled backoff has not elapsed yet.
-        immediateResult <- cb.protect(IO.pure("test")).attempt
+        _            <- IO.sleep(20.millis)
+        // Fiber 1: signals when it has entered the Probing action, then waits for latch.
+        // This holds the Probing slot and keeps state=Probing while waiting.
+        f1           <- cb.protect(started.complete(()) >> latch.get >> IO.pure(())).start
+        // Wait until fiber 1 has claimed the Probing slot (state=Probing)
+        _            <- started.get
+        // Fiber 2: state is now Probing, so it should be rejected immediately (fail fast).
+        fiber2Result <- cb.protect(IO.raiseError(new Exception("concurrent attempt"))).attempt
+        // Release fiber 1 to succeed and close the circuit
+        _            <- latch.complete(())
+        _            <- f1.join
+        finalState   <- cb.state
+        // After the successful probe, normal requests should pass through
+        afterResult  <- cb.protect(IO.pure("recovered")).attempt
       yield
-        assertEquals(finalState, CircuitBreaker.State.Open)
-        assert(immediateResult.isLeft, "Circuit breaker should remain open due to exponential backoff")
+        // Fiber 2 must be rejected with "circuit breaker is open" while probing is in progress
+        assert(fiber2Result.isLeft, "Concurrent request should be rejected while probing")
+        fiber2Result.left.foreach { err =>
+          assert(err.getMessage.contains("Circuit breaker is open"), s"Unexpected error: ${err.getMessage}")
+        }
+        // After fiber 1's successful probe the circuit should be closed
+        assertEquals(finalState, CircuitBreaker.State.Closed)
+        assert(afterResult.isRight, "Requests should succeed after circuit is closed")
     }
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

### Root Cause

`CircuitBreaker` had two non-atomic state transitions that allowed multiple concurrent
fibers to enter the HalfOpen test slot simultaneously:

1. **Open → HalfOpen**: `stateRef.set(HalfOpen)` was not atomic with the preceding
   `checkIfShouldTransitionToHalfOpen` check, so every fiber that passed the timeout
   check could set the state and recurse into `protect`.
2. **HalfOpen → test execution**: No guard existed to limit the test slot to one fiber,
   allowing all fibers that observed `HalfOpen` to execute the probe action concurrently.
   A concurrent success could then call `reset()` after a concurrent failure had already
   set the increased backoff timeout, silently erasing the escalation.

### Fix

**New `Probing` state** is added to `CircuitBreaker.State` to represent
"HalfOpen with one fiber actively verifying service recovery". This makes the
single-test-slot invariant explicit and observable via `cb.state`.

**Atomic transitions via `Ref.modify`** replace the previous non-atomic `set` calls:

- `Open → HalfOpen`: only the first fiber whose `modify` CAS succeeds proceeds;
  all others fail fast.
- `HalfOpen → Probing`: only one fiber claims the test slot; any fiber that
  observes `Probing` (including those arriving via the `Open` path) is rejected
  immediately.

**Cancellation safety via `guarantee`**: if the fiber holding the `Probing` slot
is cancelled before completing, the finalizer atomically restores `Probing → HalfOpen`
so the next fiber can retry. On success or failure the state is already `Closed` /
`Open` respectively, making the CAS a no-op. The finalizer is run inside an
`uncancelable` region as guaranteed by `MonadCancel.guaranteeCase`.

### State Transition Diagram


## Fixes

Fixes https://github.com/takapi327/ldbc/issues/731

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
