### PR TITLE
Bugfix/2026 05 issues 733

### DIFF
--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CharsetMapping.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/data/CharsetMapping.scala
@@ -90,7 +90,7 @@ object CharsetMapping:
       MysqlCharset(MYSQL_CHARSET_NAME_latin7, 1, 0, List("ISO-8859-13")),
       MysqlCharset(MYSQL_CHARSET_NAME_hebrew, 1, 0, List("ISO8859_8")),
       MysqlCharset(MYSQL_CHARSET_NAME_latin5, 1, 0, List("ISO8859_9")),
-      MysqlCharset(MYSQL_CHARSET_NAME_cp850, 2, 0, List("Cp850", "Cp437")),
+      MysqlCharset(MYSQL_CHARSET_NAME_cp850, 1, 0, List("Cp850", "Cp437")),
       MysqlCharset(MYSQL_CHARSET_NAME_cp852, 1, 0, List("Cp852")),
       MysqlCharset(MYSQL_CHARSET_NAME_keybcs2, 1, 0, List("Cp852")),
       MysqlCharset(MYSQL_CHARSET_NAME_cp866, 1, 0, List("Cp866")),

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/data/CharsetMappingTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/data/CharsetMappingTest.scala
@@ -339,3 +339,13 @@ class CharsetMappingTest extends FTestPlatform:
     assertEquals(cp1252, Some("latin1"))
     assertEquals(iso88591, Some("latin1"))
   }
+
+  test("Bug #733: cp850 should be a single-byte charset with mblen=1") {
+    val cp850 = CharsetMapping.getStaticMysqlCharsetByName("cp850")
+    assert(cp850.isDefined, "cp850 charset should exist in CharsetMapping")
+    assertEquals(
+      cp850.get.mblen,
+      1,
+      "cp850 is a single-byte charset (IBM PC Latin 1); mblen should be 1, not 2"
+    )
+  }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

**Root Cause**

`CharsetMapping.scala` incorrectly set `mblen` (max bytes per character) to `2` for cp850. cp850 (IBM PC Latin 1) is a single-byte encoding, so the correct value is `1`.

**Fix**

Single-line change in `CharsetMapping.scala:93`:

```scala
// Before
MysqlCharset(MYSQL_CHARSET_NAME_cp850, 2, 0, List("Cp850", "Cp437"))

// After
MysqlCharset(MYSQL_CHARSET_NAME_cp850, 1, 0, List("Cp850", "Cp437"))
```

**Test**

Added a regression test to `CharsetMappingTest.scala` that retrieves cp850 via `getStaticMysqlCharsetByName("cp850")` and asserts its `mblen` equals `1`.

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/733

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
