### PR TITLE
Bugfix/2026 05 issues 717

### DIFF
--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/builder/DataTypeCodeBuilder.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/builder/DataTypeCodeBuilder.scala
@@ -35,6 +35,8 @@ case class DataTypeCodeBuilder(scalaType: String, formatter: Naming):
         )
       case data: DataType.FLOAT =>
         s"${ data.name }[$scalaType](${ data.accuracy })" + buildNumberDataType(data.unsigned, data.zerofill)
+      case data: DataType.DOUBLE =>
+        s"${ data.name }[$scalaType](${ data.accuracy })" + buildNumberDataType(data.unsigned, data.zerofill)
       case data: DataType.StringDataType =>
         s"${ data.name }[$scalaType](${ data.length })" + buildCharacterSet(data.character, data.collate)
       case data: DataType.BINARY    => s"${ data.name }[$scalaType](${ data.length })"

--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/model/DataType.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/model/DataType.scala
@@ -110,6 +110,12 @@ object DataType:
     override val scalaType:  ScalaType      = ScalaType.Float
     override val scalaTypes: Seq[ScalaType] = Seq(ScalaType.Float, ScalaType.Double)
 
+  case class DOUBLE(accuracy: Int, unsigned: Boolean, zerofill: Boolean) extends DataType:
+    override val name:       String         = "DOUBLE"
+    override val sqlType:    Int            = Types.DOUBLE
+    override val scalaType:  ScalaType      = ScalaType.Double
+    override val scalaTypes: Seq[ScalaType] = Seq(ScalaType.Double, ScalaType.Float)
+
   case class CHAR(length: Int, character: Option[String], collate: Option[String]) extends StringDataType:
     override val name:       String         = "CHAR"
     override val sqlType:    Int            = Types.CHAR

--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
@@ -268,7 +268,7 @@ trait DataTypeParser extends SqlParser:
           case n ~ unsigned ~ zerofill =>
             n match
               case Some(m ~ _ ~ d) => DataType.DOUBLE(m, unsigned.isDefined, zerofill.isDefined)
-              case None            => DataType.DOUBLE(10, unsigned.isDefined, zerofill.isDefined)
+              case None            => DataType.DOUBLE(53, unsigned.isDefined, zerofill.isDefined)
         },
       input =>
         s"""

--- a/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
+++ b/module/ldbc-codegen/shared/src/main/scala/ldbc/codegen/parser/DataTypeParser.scala
@@ -267,8 +267,8 @@ trait DataTypeParser extends SqlParser:
         opt(unsigned) ~ opt(zerofill) ^^ {
           case n ~ unsigned ~ zerofill =>
             n match
-              case Some(m ~ _ ~ d) => DataType.FLOAT(m, unsigned.isDefined, zerofill.isDefined)
-              case None            => DataType.FLOAT(10, unsigned.isDefined, zerofill.isDefined)
+              case Some(m ~ _ ~ d) => DataType.DOUBLE(m, unsigned.isDefined, zerofill.isDefined)
+              case None            => DataType.DOUBLE(10, unsigned.isDefined, zerofill.isDefined)
         },
       input =>
         s"""

--- a/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
+++ b/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
@@ -194,10 +194,22 @@ class DataTypeParserTest extends CatsEffectSuite, DataTypeParser:
     assert(result2.successful)
     assert(result3.successful)
     assert(result4.successful)
-    assert(result1.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result1.get.getClass.getSimpleName}")
-    assert(result2.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result2.get.getClass.getSimpleName}")
-    assert(result3.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result3.get.getClass.getSimpleName}")
-    assert(result4.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result4.get.getClass.getSimpleName}")
+    assert(
+      result1.get.isInstanceOf[DataType.DOUBLE],
+      s"Expected DataType.DOUBLE but got ${ result1.get.getClass.getSimpleName }"
+    )
+    assert(
+      result2.get.isInstanceOf[DataType.DOUBLE],
+      s"Expected DataType.DOUBLE but got ${ result2.get.getClass.getSimpleName }"
+    )
+    assert(
+      result3.get.isInstanceOf[DataType.DOUBLE],
+      s"Expected DataType.DOUBLE but got ${ result3.get.getClass.getSimpleName }"
+    )
+    assert(
+      result4.get.isInstanceOf[DataType.DOUBLE],
+      s"Expected DataType.DOUBLE but got ${ result4.get.getClass.getSimpleName }"
+    )
   }
 
   test("DOUBLE data type parsing test fails.") {

--- a/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
+++ b/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/parser/DataTypeParserTest.scala
@@ -185,6 +185,21 @@ class DataTypeParserTest extends CatsEffectSuite, DataTypeParser:
     assert(parseAll(doubleType, "REAL UNSIGNED ZEROFILL").successful)
   }
 
+  test("Bug #717: DOUBLE data type parsing should produce DataType.DOUBLE, not DataType.FLOAT.") {
+    val result1 = parseAll(doubleType, "DOUBLE")
+    val result2 = parseAll(doubleType, "DOUBLE(24, 24)")
+    val result3 = parseAll(doubleType, "REAL")
+    val result4 = parseAll(doubleType, "REAL(24, 24)")
+    assert(result1.successful)
+    assert(result2.successful)
+    assert(result3.successful)
+    assert(result4.successful)
+    assert(result1.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result1.get.getClass.getSimpleName}")
+    assert(result2.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result2.get.getClass.getSimpleName}")
+    assert(result3.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result3.get.getClass.getSimpleName}")
+    assert(result4.get.isInstanceOf[DataType.DOUBLE], s"Expected DataType.DOUBLE but got ${result4.get.getClass.getSimpleName}")
+  }
+
   test("DOUBLE data type parsing test fails.") {
     assert(!parseAll(doubleType, "failed").successful)
     assert(!parseAll(doubleType, "double(23, 24)").successful)


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

**Root Cause**

`DataTypeParser.doubleType` constructed `DataType.FLOAT` for both `DOUBLE` and `REAL` keywords, and `DataType.DOUBLE` did not exist. This caused 64-bit database columns to silently map to Scala's 32-bit `Float` type.

**Changes**

- **`DataType.scala`**: Added `DataType.DOUBLE` case class with `sqlType = Types.DOUBLE` and `scalaType = ScalaType.Double`
- **`DataTypeParser.scala`**: Updated `doubleType` parser to return `DataType.DOUBLE` instead of `DataType.FLOAT`
- **`DataTypeCodeBuilder.scala`**: Added a `DataType.DOUBLE` match arm to generate the correct code string

**Test**

Added a regression test to `DataTypeParserTest.scala` that asserts parsing `DOUBLE` and `REAL` produces `DataType.DOUBLE` instances, not `DataType.FLOAT`.

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/717

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
