### PR TITLE
Bugfix/2026 05 issues 720

### DIFF
--- a/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypes.scala
+++ b/module/ldbc-schema/src/main/scala/ldbc/schema/DataTypes.scala
@@ -121,7 +121,7 @@ trait DataTypes:
     else CChar(length, isOptional[T])
 
   inline def VARCHAR[T <: String | Option[String]](inline length: Int): Varchar[T] =
-    inline if length < 0 || length > 255 then error("The length of the VARCHAR must be in the range 0 to 255.")
+    inline if length < 0 || length > 65535 then error("The length of the VARCHAR must be in the range 0 to 65535.")
     else Varchar(length, isOptional[T])
 
   inline def BINARY[T <: Array[Byte] | Option[Array[Byte]]](inline length: Int): Binary[T] =

--- a/module/ldbc-schema/src/test/scala/ldbc/schema/DataTypesTest.scala
+++ b/module/ldbc-schema/src/test/scala/ldbc/schema/DataTypesTest.scala
@@ -328,12 +328,33 @@ class DataTypesTest extends AnyFlatSpec:
     """.stripMargin)
   }
 
-  it should "If the length at the time of VARCHAR generation is greater than 255, an error occurs." in {
+  it should "If the length at the time of VARCHAR generation is greater than 65535, an error occurs." in {
     assertDoesNotCompile("""
       import ldbc.schema.*
       import ldbc.schema.DataType.*
 
-      val p: Varchar[String] = VARCHAR[String](256)
+      val p: Varchar[String] = VARCHAR[String](65536)
+    """.stripMargin)
+  }
+
+  it should "Bug #720: VARCHAR length up to 65535 should be valid." in {
+    assertCompiles("""
+      import ldbc.schema.*
+      import ldbc.schema.DataType.*
+
+      val p1: Varchar[String] = VARCHAR[String](256)
+      val p2: Varchar[String] = VARCHAR[String](500)
+      val p3: Varchar[String] = VARCHAR[String](1000)
+      val p4: Varchar[String] = VARCHAR[String](65535)
+    """.stripMargin)
+  }
+
+  it should "Bug #720: VARCHAR length greater than 65535 should cause a compile error." in {
+    assertDoesNotCompile("""
+      import ldbc.schema.*
+      import ldbc.schema.DataType.*
+
+      val p: Varchar[String] = VARCHAR[String](65536)
     """.stripMargin)
   }
 


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->

**Root Cause**

`DataTypes.scala` validated `VARCHAR` length with `length > 255`, which is the correct limit for `CHAR` — not `VARCHAR`. MySQL supports `VARCHAR` lengths up to 65,535. The validation was copy-pasted from the `CHAR` implementation without updating the threshold.

**Fix**

Single-line change in `DataTypes.scala`:

```scala
// Before
inline if length < 0 || length > 255 then error("The length of the VARCHAR must be in the range 0 to 255.")

// After
inline if length < 0 || length > 65535 then error("The length of the VARCHAR must be in the range 0 to 65535.")
```

**Test**

- Updated the existing incorrect test (asserting `256` causes an error) to use `65536`
- Added a regression test asserting that lengths `256`, `500`, `1000`, and `65535` all compile successfully
- Added a test asserting that `65536` causes a compile error

## Fixes

Fixes https://github.com/takapi327/ldbc/issues/720

## Pull Request Checklist

- [x] Wrote unit and integration tests
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [x] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
