### PR TITLE
Enhancement/2026 07 auth guard

### DIFF
--- a/module/ldbc-aws-authentication-plugin/shared/src/test/scala/ldbc/amazon/auth/credentials/AwsCredentialsToStringTest.scala
+++ b/module/ldbc-aws-authentication-plugin/shared/src/test/scala/ldbc/amazon/auth/credentials/AwsCredentialsToStringTest.scala
@@ -36,10 +36,7 @@ class AwsCredentialsToStringTest extends CatsEffectSuite:
 
     val rendered = credentials.toString
 
-    // The access key ID is public and may appear.
     assert(rendered.contains(testAccessKeyId))
-
-    // The secret access key MUST NOT appear in any string representation.
     assert(
       !rendered.contains(testSecretAccessKey),
       s"secretAccessKey leaked in toString: $rendered"

--- a/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/builder/ColumnCodeInjectionTest.scala
+++ b/module/ldbc-codegen/shared/src/test/scala/ldbc/codegen/builder/ColumnCodeInjectionTest.scala
@@ -26,7 +26,6 @@ class ColumnCodeInjectionTest extends CatsEffectSuite:
   test("COMMENT must escape the message into a valid Scala string literal") {
     val column = ColumnDefinition("c1", DataType.VARCHAR(255, None, None), Some(List(CommentSet("a\"); evil(); (\""))))
     val code   = builder.build(column, None)
-    // The quote must be escaped so the message stays inside the COMMENT("...") string literal.
     assert(code.contains("COMMENT(\"a\\\"); evil(); (\\\"\")"), code)
     assert(!code.contains("COMMENT(\"a\"); evil"), code)
   }

--- a/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/Protocol.scala
+++ b/module/ldbc-connector/shared/src/main/scala/ldbc/connector/net/Protocol.scala
@@ -308,6 +308,7 @@ object Protocol:
     private def readUntilOk(
       plugin:       AuthenticationPlugin[F],
       password:     String,
+      span:         Span[F],
       scrambleBuff: Option[Array[Byte]] = None
     ): F[Unit] =
       socket.receive(AuthenticationPacket.decoder(initialPacket.capabilityFlags)).flatMap {
@@ -322,14 +323,15 @@ object Protocol:
                 scrambleBuff.getOrElse(initialPacket.scrambleBuff)
               ) *> readUntilOk(
                 plugin,
-                password
+                password,
+                span
               )
             case plugin: Sha256PasswordPlugin[F] =>
               sha256Authentication(
                 plugin,
                 password,
                 scrambleBuff.getOrElse(initialPacket.scrambleBuff)
-              ) *> readUntilOk(plugin, password)
+              ) *> readUntilOk(plugin, password, span)
             case unknown =>
               ev.raiseError(
                 new SQLInvalidAuthorizationSpecException(
@@ -342,8 +344,8 @@ object Protocol:
                   )
                 )
               )
-        case more: AuthMoreDataPacket        => readUntilOk(plugin, password)
-        case packet: AuthSwitchRequestPacket => changeAuthenticationMethod(packet, password)
+        case more: AuthMoreDataPacket        => readUntilOk(plugin, password, span)
+        case packet: AuthSwitchRequestPacket => changeAuthenticationMethod(packet, password, span)
         case _: OKPacket                     => ev.unit
         case error: ERRPacket                =>
           ev.raiseError(
@@ -374,34 +376,41 @@ object Protocol:
      * @param switchRequestPacket
      * Authentication method Switch Request Packet
      */
-    private def changeAuthenticationMethod(switchRequestPacket: AuthSwitchRequestPacket, password: String): F[Unit] =
-      determinatePlugin(switchRequestPacket.pluginName) match
-        case Left(error)                                 => ev.raiseError(error) *> socket.send(ComQuitPacket())
-        case Right(plugin: CachingSha2PasswordPlugin[F]) =>
+    private def changeAuthenticationMethod(
+      switchRequestPacket: AuthSwitchRequestPacket,
+      password:            String,
+      span:                Span[F]
+    ): F[Unit] =
+      resolveAuthPlugin(switchRequestPacket.pluginName, span).flatMap {
+        case plugin: CachingSha2PasswordPlugin[F] =>
           for
             hashedPassword <- plugin.hashPassword(password, switchRequestPacket.pluginProvidedData)
             _              <- socket.send(AuthSwitchResponsePacket(hashedPassword))
             _              <- readUntilOk(
                    plugin,
                    password,
+                   span,
                    Some(switchRequestPacket.pluginProvidedData)
                  )
           yield ()
-        case Right(plugin: Sha256PasswordPlugin[F]) =>
+        case plugin: Sha256PasswordPlugin[F] =>
           sha256Authentication(plugin, password, switchRequestPacket.pluginProvidedData) *> readUntilOk(
             plugin,
-            password
+            password,
+            span
           )
-        case Right(plugin) =>
+        case plugin =>
           for
             hashedPassword <- plugin.hashPassword(password, switchRequestPacket.pluginProvidedData)
             _              <- socket.send(AuthSwitchResponsePacket(hashedPassword))
             _              <- readUntilOk(
                    plugin,
                    password,
+                   span,
                    Some(switchRequestPacket.pluginProvidedData)
                  )
           yield ()
+      }
 
     /**
      * Plain text handshake
@@ -513,59 +522,56 @@ object Protocol:
 
     override def startAuthentication(username: String, password: String): F[Unit] =
       exchange[F, Unit](TelemetrySpanName.CONNECTION_CREATE) { (span: Span[F]) =>
+        val resolvedPlugin: F[AuthenticationPlugin[F]] =
+          defaultAuthenticationPlugin match
+            case Some(plugin) => checkRequiresConfidentiality(plugin, span).as(plugin)
+            case None         => resolveAuthPlugin(initialPacket.authPlugin, span)
         span.addAttributes(
           (attributes ++ List(
             TelemetryAttribute.dbMysqlAuthPlugin(initialPacket.authPlugin),
             Attribute("username", username)
           ))*
-        ) *> (
-          defaultAuthenticationPlugin match
-            case Some(plugin) =>
-              checkRequiresConfidentiality(plugin, span) *> handshake(plugin, username, password) *> readUntilOk(
-                plugin,
-                password
-              )
-            case None =>
-              determinatePlugin(initialPacket.authPlugin) match
-                case Left(error) =>
-                  span.recordException(error) *>
-                    span.setStatus(StatusCode.Error, error.getMessage) *>
-                    ev.raiseError(error) *>
-                    socket.send(ComQuitPacket())
-                case Right(plugin) =>
-                  checkRequiresConfidentiality(plugin, span) *> handshake(plugin, username, password) *> readUntilOk(
-                    plugin,
-                    password
-                  )
+        ) *> resolvedPlugin.flatMap(plugin =>
+          handshake(plugin, username, password) *> readUntilOk(plugin, password, span)
         )
       }
 
     override def changeUser(user: String, password: String): F[Unit] =
       exchange[F, Unit](TelemetrySpanName.CHANGE_USER) { (span: Span[F]) =>
-        span.addAttributes(attributes*) *> (
-          determinatePlugin(initialPacket.authPlugin) match
-            case Left(error) =>
-              span.recordException(error) *>
-                span.setStatus(StatusCode.Error, error.getMessage) *>
-                ev.raiseError(error) *>
-                socket.send(ComQuitPacket())
-            case Right(plugin) =>
-              for
-                hashedPassword <- plugin.hashPassword(password, initialPacket.scrambleBuff)
-                _              <- socket.send(
-                       ComChangeUserPacket(
-                         capabilityFlags,
-                         user,
-                         hostInfo.database,
-                         initialPacket.characterSet,
-                         initialPacket.authPlugin,
-                         hashedPassword
-                       )
-                     )
-                _ <- readUntilOk(plugin, password)
-              yield ()
+        span.addAttributes(attributes*) *> resolveAuthPlugin(initialPacket.authPlugin, span).flatMap(plugin =>
+          for
+            hashedPassword <- plugin.hashPassword(password, initialPacket.scrambleBuff)
+            _              <- socket.send(
+                   ComChangeUserPacket(
+                     capabilityFlags,
+                     user,
+                     hostInfo.database,
+                     initialPacket.characterSet,
+                     initialPacket.authPlugin,
+                     hashedPassword
+                   )
+                 )
+            _ <- readUntilOk(plugin, password, span)
+          yield ()
         )
       }
+
+    /**
+     * Resolves the authentication plugin the server asked for by name and immediately enforces the
+     * confidentiality guard, before any authentication response is generated. This runs on every
+     * plugin (re)selection — initial handshake, Change User, and a server-driven AuthSwitchRequest —
+     * so a plugin that transmits credentials in cleartext can never be used over a non-SSL
+     * connection. Fails closed (sends ComQuit, then raises) on an unknown plugin.
+     */
+    private def resolveAuthPlugin(pluginName: String, span: Span[F]): F[AuthenticationPlugin[F]] =
+      determinatePlugin(pluginName) match
+        case Left(error) =>
+          span.recordException(error) *>
+            span.setStatus(StatusCode.Error, error.getMessage) *>
+            socket.send(ComQuitPacket()) *>
+            ev.raiseError(error)
+        case Right(plugin) =>
+          checkRequiresConfidentiality(plugin, span).as(plugin)
 
     private def checkRequiresConfidentiality(plugin: AuthenticationPlugin[F], span: Span[F]): F[Unit] =
       if plugin.requiresConfidentiality && !useSSL then

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/CredentialRedactionTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/CredentialRedactionTest.scala
@@ -29,11 +29,8 @@ class CredentialRedactionTest extends FTestPlatform:
 
     val rendered = dataSource.toString
 
-    // Non-sensitive connection fields remain visible for debugging.
     assert(rendered.contains("localhost"))
     assert(rendered.contains("myuser"))
-
-    // The password MUST NOT appear in any string representation.
     assert(!rendered.contains(secret), s"password leaked in toString: $rendered")
   }
 

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
@@ -6,8 +6,8 @@
 
 package ldbc.connector.net
 
-import scodec.Decoder
 import scodec.bits.ByteVector
+import scodec.Decoder
 
 import cats.effect.*
 
@@ -17,15 +17,15 @@ import org.typelevel.otel4s.trace.Tracer
 
 import munit.CatsEffectSuite
 
-import ldbc.authentication.plugin.MysqlClearPasswordPlugin
-
 import ldbc.connector.authenticator.MysqlNativePasswordPlugin
 import ldbc.connector.data.{ CapabilitiesFlags, ServerStatusFlags }
-import ldbc.connector.util.Version
 import ldbc.connector.net.packet.{ RequestPacket, ResponsePacket }
 import ldbc.connector.net.packet.request.AuthSwitchResponsePacket
 import ldbc.connector.net.packet.response.{ AuthSwitchRequestPacket, InitialPacket, OKPacket }
 import ldbc.connector.net.protocol.Exchange
+import ldbc.connector.util.Version
+
+import ldbc.authentication.plugin.MysqlClearPasswordPlugin
 
 /**
  * Verification test for the security finding: the confidentiality guard is applied only on the
@@ -48,13 +48,15 @@ class AuthDowngradeTest extends CatsEffectSuite:
     toReceive: Ref[IO, List[ResponsePacket]]
   ) extends PacketSocket[IO]:
     override def receive[P <: ResponsePacket](decoder: Decoder[P]): IO[P] =
-      toReceive.modify {
-        case head :: tail => (tail, Some(head))
-        case Nil          => (Nil, None)
-      }.flatMap {
-        case Some(packet) => IO.pure(packet.asInstanceOf[P])
-        case None         => IO.raiseError(new RuntimeException("scripted socket exhausted"))
-      }
+      toReceive
+        .modify {
+          case head :: tail => (tail, Some(head))
+          case Nil          => (Nil, None)
+        }
+        .flatMap {
+          case Some(packet) => IO.pure(packet.asInstanceOf[P])
+          case None         => IO.raiseError(new RuntimeException("scripted socket exhausted"))
+        }
     override def send(request: RequestPacket): IO[Unit] = sent.update(_ :+ request)
 
   private val initialPacket = InitialPacket(
@@ -92,7 +94,7 @@ class AuthDowngradeTest extends CatsEffectSuite:
                    capabilityFlags             = Set.empty[CapabilitiesFlags],
                    sequenceIdRef               = null,
                    defaultAuthenticationPlugin = None,
-                   plugins = Map(
+                   plugins                     = Map(
                      "mysql_native_password" -> MysqlNativePasswordPlugin[IO](),
                      "mysql_clear_password"  -> MysqlClearPasswordPlugin[IO]()
                    )
@@ -106,13 +108,14 @@ class AuthDowngradeTest extends CatsEffectSuite:
       }
       (result, leaked)
 
-    program.map { case (result, leaked) =>
-      assert(!leaked, "cleartext password was sent over a non-SSL connection")
-      assert(result.isLeft, s"expected authentication to fail (SSL required), but got $result")
-      assert(
-        result.left.exists(_.getMessage.contains("SSL connection required")),
-        s"expected an 'SSL connection required' error, got $result"
-      )
+    program.map {
+      case (result, leaked) =>
+        assert(!leaked, "cleartext password was sent over a non-SSL connection")
+        assert(result.isLeft, s"expected authentication to fail (SSL required), but got $result")
+        assert(
+          result.left.exists(_.getMessage.contains("SSL connection required")),
+          s"expected an 'SSL connection required' error, got $result"
+        )
     }
   }
 
@@ -132,17 +135,18 @@ class AuthDowngradeTest extends CatsEffectSuite:
                    capabilityFlags             = Set.empty[CapabilitiesFlags],
                    sequenceIdRef               = null,
                    defaultAuthenticationPlugin = None,
-                   plugins = Map("mysql_clear_password" -> MysqlClearPasswordPlugin[IO]())
+                   plugins                     = Map("mysql_clear_password" -> MysqlClearPasswordPlugin[IO]())
                  )
       result <- protocol.changeUser("user", "secret").attempt
       sends  <- sent.get
     yield (result, sends)
 
-    program.map { case (result, sends) =>
-      assert(sends.isEmpty, s"expected no packet to be sent, but sent: $sends")
-      assert(
-        result.left.exists(_.getMessage.contains("SSL connection required")),
-        s"expected an 'SSL connection required' error, got $result"
-      )
+    program.map {
+      case (result, sends) =>
+        assert(sends.isEmpty, s"expected no packet to be sent, but sent: $sends")
+        assert(
+          result.left.exists(_.getMessage.contains("SSL connection required")),
+          s"expected an 'SSL connection required' error, got $result"
+        )
     }
   }

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
@@ -79,9 +79,7 @@ class AuthDowngradeTest extends CatsEffectSuite:
       sent               <- Ref[IO].of(Vector.empty[RequestPacket])
       toReceive          <- Ref[IO].of(
                      List[ResponsePacket](
-                       // server forces a switch to the cleartext plugin ...
                        AuthSwitchRequestPacket(0xfe, "mysql_clear_password", Array.fill[Byte](20)(2)),
-                       // ... then would accept the harvested cleartext.
                        OKPacket(0x00, 0L, 0L, Set.empty[ServerStatusFlags], None, None, None, None)
                      )
                    )
@@ -111,6 +109,37 @@ class AuthDowngradeTest extends CatsEffectSuite:
     program.map { case (result, leaked) =>
       assert(!leaked, "cleartext password was sent over a non-SSL connection")
       assert(result.isLeft, s"expected authentication to fail (SSL required), but got $result")
+      assert(
+        result.left.exists(_.getMessage.contains("SSL connection required")),
+        s"expected an 'SSL connection required' error, got $result"
+      )
+    }
+  }
+
+  test("changeUser to a confidentiality-requiring plugin over a non-SSL connection must be rejected") {
+    val clearTextInitialPacket = initialPacket.copy(authPlugin = "mysql_clear_password")
+
+    val program = for
+      given Exchange[IO] <- Exchange[IO]
+      sent               <- Ref[IO].of(Vector.empty[RequestPacket])
+      toReceive          <- Ref[IO].of(List.empty[ResponsePacket])
+      protocol = Protocol.Impl[IO](
+                   initialPacket               = clearTextInitialPacket,
+                   hostInfo                    = hostInfo,
+                   socket                      = new ScriptedSocket(sent, toReceive),
+                   useSSL                      = false,
+                   allowPublicKeyRetrieval     = false,
+                   capabilityFlags             = Set.empty[CapabilitiesFlags],
+                   sequenceIdRef               = null,
+                   defaultAuthenticationPlugin = None,
+                   plugins = Map("mysql_clear_password" -> MysqlClearPasswordPlugin[IO]())
+                 )
+      result <- protocol.changeUser("user", "secret").attempt
+      sends  <- sent.get
+    yield (result, sends)
+
+    program.map { case (result, sends) =>
+      assert(sends.isEmpty, s"expected no packet to be sent, but sent: $sends")
       assert(
         result.left.exists(_.getMessage.contains("SSL connection required")),
         s"expected an 'SSL connection required' error, got $result"

--- a/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
+++ b/module/ldbc-connector/shared/src/test/scala/ldbc/connector/net/AuthDowngradeTest.scala
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2023-2025 by Takahiko Tominaga
+ * This software is licensed under the MIT License (MIT).
+ * For more information see LICENSE or https://opensource.org/licenses/MIT
+ */
+
+package ldbc.connector.net
+
+import scodec.Decoder
+import scodec.bits.ByteVector
+
+import cats.effect.*
+
+import fs2.hashing.Hashing
+
+import org.typelevel.otel4s.trace.Tracer
+
+import munit.CatsEffectSuite
+
+import ldbc.authentication.plugin.MysqlClearPasswordPlugin
+
+import ldbc.connector.authenticator.MysqlNativePasswordPlugin
+import ldbc.connector.data.{ CapabilitiesFlags, ServerStatusFlags }
+import ldbc.connector.util.Version
+import ldbc.connector.net.packet.{ RequestPacket, ResponsePacket }
+import ldbc.connector.net.packet.request.AuthSwitchResponsePacket
+import ldbc.connector.net.packet.response.{ AuthSwitchRequestPacket, InitialPacket, OKPacket }
+import ldbc.connector.net.protocol.Exchange
+
+/**
+ * Verification test for the security finding: the confidentiality guard is applied only on the
+ * initial handshake, not on the server-driven `AuthSwitchRequest` path. A rogue / MITM server can
+ * therefore ask a non-SSL client to switch to `mysql_clear_password` and harvest the cleartext
+ * password, bypassing the guard that `startAuthentication` would otherwise enforce.
+ *
+ * The test drives the real auth flow over a scripted socket. It asserts the SECURE behaviour: the
+ * client must fail with an "SSL connection required" error and must NOT send the cleartext password.
+ * While the guard is missing on the switch path, this test FAILS.
+ */
+class AuthDowngradeTest extends CatsEffectSuite:
+
+  given Tracer[IO]  = Tracer.noop[IO]
+  given Hashing[IO] = Hashing.forSync[IO]
+
+  /** A PacketSocket that records everything sent and replays a scripted list of server packets. */
+  private final class ScriptedSocket(
+    sent:      Ref[IO, Vector[RequestPacket]],
+    toReceive: Ref[IO, List[ResponsePacket]]
+  ) extends PacketSocket[IO]:
+    override def receive[P <: ResponsePacket](decoder: Decoder[P]): IO[P] =
+      toReceive.modify {
+        case head :: tail => (tail, Some(head))
+        case Nil          => (Nil, None)
+      }.flatMap {
+        case Some(packet) => IO.pure(packet.asInstanceOf[P])
+        case None         => IO.raiseError(new RuntimeException("scripted socket exhausted"))
+      }
+    override def send(request: RequestPacket): IO[Unit] = sent.update(_ :+ request)
+
+  private val initialPacket = InitialPacket(
+    protocolVersion = 10,
+    serverVersion   = Version(8, 4, 0),
+    threadId        = 1,
+    capabilityFlags = Set.empty[CapabilitiesFlags],
+    characterSet    = 45,
+    statusFlags     = Set.empty[ServerStatusFlags],
+    scrambleBuff    = Array.fill[Byte](20)(1),
+    authPlugin      = "mysql_native_password"
+  )
+
+  private val hostInfo = HostInfo("127.0.0.1", 3306, "user", Some("secret"), Some("db"))
+
+  test("a rogue AuthSwitchRequest to mysql_clear_password over a non-SSL connection must be rejected") {
+    val password  = "secret"
+    val cleartext = ByteVector(password.getBytes("UTF-8"))
+
+    val program = for
+      given Exchange[IO] <- Exchange[IO]
+      sent               <- Ref[IO].of(Vector.empty[RequestPacket])
+      toReceive          <- Ref[IO].of(
+                     List[ResponsePacket](
+                       // server forces a switch to the cleartext plugin ...
+                       AuthSwitchRequestPacket(0xfe, "mysql_clear_password", Array.fill[Byte](20)(2)),
+                       // ... then would accept the harvested cleartext.
+                       OKPacket(0x00, 0L, 0L, Set.empty[ServerStatusFlags], None, None, None, None)
+                     )
+                   )
+      protocol = Protocol.Impl[IO](
+                   initialPacket               = initialPacket,
+                   hostInfo                    = hostInfo,
+                   socket                      = new ScriptedSocket(sent, toReceive),
+                   useSSL                      = false,
+                   allowPublicKeyRetrieval     = false,
+                   capabilityFlags             = Set.empty[CapabilitiesFlags],
+                   sequenceIdRef               = null,
+                   defaultAuthenticationPlugin = None,
+                   plugins = Map(
+                     "mysql_native_password" -> MysqlNativePasswordPlugin[IO](),
+                     "mysql_clear_password"  -> MysqlClearPasswordPlugin[IO]()
+                   )
+                 )
+      result <- protocol.startAuthentication("user", password).attempt
+      sends  <- sent.get
+    yield
+      val leaked = sends.exists {
+        case r: AuthSwitchResponsePacket => r.hashedPassword == cleartext
+        case _                           => false
+      }
+      (result, leaked)
+
+    program.map { case (result, leaked) =>
+      assert(!leaked, "cleartext password was sent over a non-SSL connection")
+      assert(result.isLeft, s"expected authentication to fail (SSL required), but got $result")
+      assert(
+        result.left.exists(_.getMessage.contains("SSL connection required")),
+        s"expected an 'SSL connection required' error, got $result"
+      )
+    }
+  }

--- a/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/IdentSqlInjectionTest.scala
+++ b/module/ldbc-dsl/src/test/scala/ldbc/dsl/syntax/IdentSqlInjectionTest.scala
@@ -38,9 +38,9 @@ class IdentSqlInjectionTest extends CatsEffectSuite with HelperFunctionsSyntax:
     while i < sql.length && !closed do
       sql.charAt(i) match
         case '`' if i + 1 < sql.length && sql.charAt(i + 1) == '`' =>
-          sb.append('`'); i += 2 // escaped backtick
+          sb.append('`'); i += 2
         case '`' =>
-          closed = true; i += 1 // closing backtick
+          closed = true; i += 1
         case c =>
           sb.append(c); i += 1
     (sb.result(), i)
@@ -51,7 +51,6 @@ class IdentSqlInjectionTest extends CatsEffectSuite with HelperFunctionsSyntax:
     val query     = sql"SELECT * FROM ${ ident(malicious) }"
     val statement = query.statement
 
-    // Locate the identifier that follows "FROM ".
     val fromIdx = statement.indexOf("FROM `")
     assert(fromIdx >= 0, s"expected a backtick identifier after FROM in: $statement")
     val identStart = fromIdx + "FROM ".length
@@ -59,8 +58,6 @@ class IdentSqlInjectionTest extends CatsEffectSuite with HelperFunctionsSyntax:
     val (decoded, afterIdx) = parseBacktickIdentifier(statement, identStart)
     val trailing            = statement.substring(afterIdx)
 
-    // Secure expectation: the MySQL parser must see the ENTIRE malicious string as the identifier,
-    // leaving no executable SQL after it.
     assertEquals(
       decoded,
       malicious,
@@ -74,7 +71,6 @@ class IdentSqlInjectionTest extends CatsEffectSuite with HelperFunctionsSyntax:
   }
 
   test("ident() escapes a backtick by doubling it, not with a backslash") {
-    // At the Parameter.Static level the escaped form must double the backtick.
     val col = ident("a`b")
     assertEquals(col, Parameter.Static("`a``b`"))
   }


### PR DESCRIPTION
## Implementation Details

<!-- Please write a complete description of the changes you are introducing in this PR -->
Enforce the confidentiality guard on all authentication paths

The SSL-required guard (`checkRequiresConfidentiality`) previously ran only on the
initial handshake. A rogue / MITM server could send an `AuthSwitchRequest`
(or trigger it via `changeUser`) to switch a **non-SSL** connection to a cleartext
plugin (`mysql_clear_password`, AWS IAM) and harvest the plaintext credential.

- Centralize plugin resolution + the guard into `resolveAuthPlugin`, and run it on
  every path where a plugin is (re)selected: initial handshake, `changeUser`, and
  server-driven `AuthSwitchRequest` (same approach as MySQL Connector/J).
- Add `AuthDowngradeTest` that reproduces the leak over a scripted socket.

## Fixes

Fixes #xxxxx

## Pull Request Checklist

- [ ] Wrote unit and integration tests
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code formatting by scalafmt (sbt scalafmtAll command execution)
- [ ] Add copyright headers to new files

## References

<!-- Please describe any relevant issues, PR, articles, etc. -->
